### PR TITLE
Fix tenant job edit form backend handling

### DIFF
--- a/Backend/admin/Models/InquilinoModel.php
+++ b/Backend/admin/Models/InquilinoModel.php
@@ -868,6 +868,50 @@ class InquilinoModel
     }
 
     /**
+     * Actualiza la información laboral almacenada en el profile.
+     */
+    public function actualizarTrabajoPorPk(string $pk, array $trabajo): bool
+    {
+        $pk = trim($pk);
+        if ($pk === '') {
+            return false;
+        }
+
+        $payload = [];
+        foreach ($trabajo as $campo => $valor) {
+            if (!is_string($campo)) {
+                continue;
+            }
+
+            if (is_string($valor)) {
+                $payload[$campo] = $valor;
+            } elseif (is_int($valor) || is_float($valor)) {
+                $payload[$campo] = (float)$valor;
+            } elseif ($valor === null) {
+                $payload[$campo] = null;
+            }
+        }
+
+        if (!$payload) {
+            return false;
+        }
+
+        $this->client->updateItem([
+            'TableName' => $this->table,
+            'Key'       => [
+                'pk' => ['S' => $pk],
+                'sk' => ['S' => 'profile'],
+            ],
+            'UpdateExpression'          => 'SET trabajo = :trabajo',
+            'ExpressionAttributeValues' => [
+                ':trabajo' => $this->marshaler->marshalValue($payload),
+            ],
+        ]);
+
+        return true;
+    }
+
+    /**
      * Obtiene el snapshot de validaciones normalizado.
      */
     public function obtenerValidaciones(int $idInquilino): array

--- a/Backend/admin/Views/inquilino/detalle.php
+++ b/Backend/admin/Views/inquilino/detalle.php
@@ -442,6 +442,8 @@ $selfieUrl    = $selfieUrl ?? null;
                 autocomplete="off"
                 onsubmit="guardarEdicionTrabajo(event)">
                 <input type="hidden" name="id_inquilino" value="<?= $profile['id']; ?>">
+                <input type="hidden" name="pk" value="<?= htmlspecialchars($profile['pk'] ?? ''); ?>">
+                <input type="hidden" name="id" value="<?= (int)($profile['id'] ?? 0); ?>">
                 <div class="grid md:grid-cols-2 gap-6">
                     <div>
                         <label class="block text-gray-200 font-semibold mb-1">Empresa</label>

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -390,6 +390,11 @@ switch (true) {
         (new \App\Controllers\InquilinoController())->editarDomicilio();
         exit;
         break;
+    case $uri === '/inquilino/editar_trabajo' && $_SERVER['REQUEST_METHOD'] === 'POST':
+        require __DIR__ . '/Controllers/InquilinoController.php';
+        (new \App\Controllers\InquilinoController())->editarTrabajo();
+        exit;
+        break;
 
     case $uri === '/financieros' || $uri === '/financieros/index':
         require __DIR__ . '/Controllers/FinancieroController.php';


### PR DESCRIPTION
## Summary
- add missing POST route and controller action to update tenant job information
- persist job updates through the model and include required identifiers in the edit form

## Testing
- php -l Backend/admin/Controllers/InquilinoController.php
- php -l Backend/admin/Models/InquilinoModel.php
- php -l Backend/admin/Views/inquilino/detalle.php

------
https://chatgpt.com/codex/tasks/task_e_68cb978981648323b222100eb68cfc60