### PR TITLE
Fix edición de fiador para inquilinos

### DIFF
--- a/Backend/admin/Controllers/InquilinoController.php
+++ b/Backend/admin/Controllers/InquilinoController.php
@@ -323,6 +323,82 @@ class InquilinoController
     }
 
     /**
+     * Actualiza la información del inmueble en garantía registrado para el fiador.
+     */
+    public function editarFiador(): void
+    {
+        header('Content-Type: application/json; charset=utf-8');
+
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['ok' => false, 'error' => 'Metodo no permitido']);
+            return;
+        }
+
+        $pk = trim($_POST['pk'] ?? '');
+        if ($pk === '') {
+            http_response_code(400);
+            echo json_encode(['ok' => false, 'error' => 'PK requerida']);
+            return;
+        }
+
+        $id = (int)($_POST['id'] ?? 0);
+        if ($id <= 0 && preg_match('/^[a-z]+#(\d+)$/i', $pk, $m)) {
+            $id = (int)$m[1];
+        }
+
+        if ($id <= 0) {
+            http_response_code(400);
+            echo json_encode(['ok' => false, 'error' => 'ID invalido']);
+            return;
+        }
+
+        $fiador = [
+            'calle_inmueble'   => trim((string)($_POST['calle_inmueble'] ?? '')),
+            'num_ext_inmueble' => trim((string)($_POST['num_ext_inmueble'] ?? '')),
+            'num_int_inmueble' => trim((string)($_POST['num_int_inmueble'] ?? '')),
+            'colonia_inmueble' => trim((string)($_POST['colonia_inmueble'] ?? '')),
+            'alcaldia_inmueble'=> trim((string)($_POST['alcaldia_inmueble'] ?? '')),
+            'estado_inmueble'  => trim((string)($_POST['estado_inmueble'] ?? '')),
+            'numero_escritura' => trim((string)($_POST['numero_escritura'] ?? '')),
+            'numero_notario'   => trim((string)($_POST['numero_notario'] ?? '')),
+            'estado_notario'   => trim((string)($_POST['estado_notario'] ?? '')),
+            'folio_real'       => trim((string)($_POST['folio_real'] ?? '')),
+        ];
+
+        $camposRequeridos = [
+            'calle_inmueble',
+            'num_ext_inmueble',
+            'colonia_inmueble',
+            'alcaldia_inmueble',
+            'estado_inmueble',
+        ];
+
+        foreach ($camposRequeridos as $campo) {
+            if ($fiador[$campo] === '') {
+                http_response_code(400);
+                echo json_encode(['ok' => false, 'error' => 'Completa todos los campos obligatorios del inmueble']);
+                return;
+            }
+        }
+
+        try {
+            $ok = $this->model->actualizarFiadorPorPk($pk, $fiador);
+
+            echo json_encode([
+                'ok'      => $ok,
+                'mensaje' => $ok ? 'Datos del fiador actualizados.' : 'No fue posible actualizar la información del fiador.',
+            ]);
+        } catch (\Throwable $e) {
+            http_response_code(500);
+            echo json_encode([
+                'ok'    => false,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
      * Muestra el detalle de un inquilino a partir del slug amigable.
      */
     public function subirArchivo(): void

--- a/Backend/admin/Models/InquilinoModel.php
+++ b/Backend/admin/Models/InquilinoModel.php
@@ -912,6 +912,54 @@ class InquilinoModel
     }
 
     /**
+     * Actualiza la información del inmueble en garantía asociada al fiador.
+     */
+    public function actualizarFiadorPorPk(string $pk, array $fiador): bool
+    {
+        $pk = trim($pk);
+        if ($pk === '') {
+            return false;
+        }
+
+        $payload = [];
+        foreach ($fiador as $campo => $valor) {
+            if (!is_string($campo)) {
+                continue;
+            }
+
+            if (!is_string($valor)) {
+                $valor = $valor === null ? null : (string)$valor;
+            }
+
+            if ($valor === null) {
+                $payload[$campo] = null;
+                continue;
+            }
+
+            $valor = trim($valor);
+            $payload[$campo] = $valor === '' ? null : $valor;
+        }
+
+        if (!$payload) {
+            return false;
+        }
+
+        $this->client->updateItem([
+            'TableName' => $this->table,
+            'Key'       => [
+                'pk' => ['S' => $pk],
+                'sk' => ['S' => 'profile'],
+            ],
+            'UpdateExpression'          => 'SET fiador = :fiador',
+            'ExpressionAttributeValues' => [
+                ':fiador' => $this->marshaler->marshalValue($payload),
+            ],
+        ]);
+
+        return true;
+    }
+
+    /**
      * Obtiene el snapshot de validaciones normalizado.
      */
     public function obtenerValidaciones(int $idInquilino): array

--- a/Backend/admin/Views/inquilino/detalle.php
+++ b/Backend/admin/Views/inquilino/detalle.php
@@ -612,6 +612,8 @@ $selfieUrl    = $selfieUrl ?? null;
                     autocomplete="off"
                     onsubmit="guardarEdicionFiador(event)">
                     <input type="hidden" name="id_inquilino" value="<?= $profile['id']; ?>">
+                    <input type="hidden" name="pk" value="<?= htmlspecialchars($profile['pk'] ?? ''); ?>">
+                    <input type="hidden" name="id" value="<?= (int)($profile['id'] ?? 0); ?>">
                     <div class="grid md:grid-cols-2 gap-6">
                         <!-- [ ... campos como los tienes ... ] -->
                         <div>

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -396,6 +396,12 @@ switch (true) {
         exit;
         break;
 
+    case $uri === '/inquilino/editar_fiador' && $_SERVER['REQUEST_METHOD'] === 'POST':
+        require __DIR__ . '/Controllers/InquilinoController.php';
+        (new \App\Controllers\InquilinoController())->editarFiador();
+        exit;
+        break;
+
     case $uri === '/financieros' || $uri === '/financieros/index':
         require __DIR__ . '/Controllers/FinancieroController.php';
         (new \App\Controllers\FinancieroController())->index();


### PR DESCRIPTION
## Summary
- Añadí los campos ocultos pk e id al formulario de edición del fiador para que envíe los identificadores necesarios
- Registré la ruta `/inquilino/editar_fiador` y su método en `InquilinoController` para validar y actualizar los datos del fiador en DynamoDB
- Incorporé en `InquilinoModel` el helper `actualizarFiadorPorPk` que guarda el bloque `fiador` en la tabla

## Testing
- php -l Backend/admin/Controllers/InquilinoController.php
- php -l Backend/admin/Models/InquilinoModel.php

------
https://chatgpt.com/codex/tasks/task_e_68cb9a738ffc8323b5ca355d2b56d433