### PR TITLE
Fix historial vivienda editing to use DynamoDB keys

### DIFF
--- a/Backend/admin/Views/inquilino/detalle.php
+++ b/Backend/admin/Views/inquilino/detalle.php
@@ -705,8 +705,9 @@ $selfieUrl    = $selfieUrl ?? null;
                 </div>
                 <!-- Formulario de edición (oculto al inicio) -->
                 <form id="form-editar-historial" class="hidden mt-8 space-y-6" autocomplete="off" onsubmit="guardarEdicionHistorial(event)">
-                    <input type="hidden" name="id" value="<?= $vivienda['id']; ?>">
-                    <input type="hidden" name="id_inquilino" value="<?= $vivienda['id_inquilino']; ?>">
+                    <input type="hidden" name="id_inquilino" value="<?= (int)($profile['id'] ?? 0); ?>">
+                    <input type="hidden" name="pk" value="<?= htmlspecialchars($profile['pk'] ?? ''); ?>">
+                    <input type="hidden" name="id" value="<?= (int)($profile['id'] ?? 0); ?>">
                     <div class="grid md:grid-cols-2 gap-6">
                         <div>
                             <label class="block text-yellow-200 font-semibold mb-1">¿Vive actualmente en este domicilio?</label>

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -401,6 +401,11 @@ switch (true) {
         (new \App\Controllers\InquilinoController())->editarFiador();
         exit;
         break;
+    case $uri === '/inquilino/editar_historial_vivienda' && $_SERVER['REQUEST_METHOD'] === 'POST':
+        require __DIR__ . '/Controllers/InquilinoController.php';
+        (new \App\Controllers\InquilinoController())->editarHistorialVivienda();
+        exit;
+        break;
 
     case $uri === '/financieros' || $uri === '/financieros/index':
         require __DIR__ . '/Controllers/FinancieroController.php';


### PR DESCRIPTION
## Summary
- add backend route and controller handler to update historial de vivienda records through DynamoDB
- persist vivienda history updates in DynamoDB with a dedicated model method
- align the historial de vivienda form with DynamoDB identifiers to avoid undefined keys

## Testing
- php -l Backend/admin/Controllers/InquilinoController.php
- php -l Backend/admin/Models/InquilinoModel.php
- php -l Backend/admin/Views/inquilino/detalle.php

------
https://chatgpt.com/codex/tasks/task_e_68cb9cc147f4832394ec815867208462