### PR TITLE
Normalize asesor keys and remove phone field

### DIFF
--- a/Backend/admin/Controllers/AsesorController.php
+++ b/Backend/admin/Controllers/AsesorController.php
@@ -135,7 +135,6 @@ class AsesorController
             'nombre_asesor' => trim($input['nombre_asesor'] ?? ''),
             'email'         => trim($input['email'] ?? ''),
             'celular'       => trim($input['celular'] ?? ''),
-            'telefono'      => trim($input['telefono'] ?? ''),
         ];
     }
 

--- a/Backend/admin/Controllers/IAController.php
+++ b/Backend/admin/Controllers/IAController.php
@@ -234,7 +234,9 @@ class IAController
                 $idInquilino = (int)$r['id'];
 
                 // --- Info base del inquilino ---
-                $info = "Sí, tenemos registrado a {$r['nombre']} con correo {$r['email']} y teléfono {$r['telefono']}.";
+                $celular = (string) ($r['celular'] ?? '');
+                $contacto = $celular !== '' ? " y celular {$celular}" : '';
+                $info = "Sí, tenemos registrado a {$r['nombre']} con correo {$r['email']}{$contacto}.";
 
                 // --- Pólizas vigentes ---
                 $db  = (new \App\Core\Database())->getDB();

--- a/Backend/admin/Controllers/InquilinoController.php
+++ b/Backend/admin/Controllers/InquilinoController.php
@@ -996,11 +996,11 @@ class InquilinoController
     {
         $asesor = $profile['asesor'] ?? null;
         if (is_array($asesor) && !empty($asesor)) {
-            if (!isset($asesor['id']) && isset($asesor['pk']) && preg_match('/^ASE#(\d+)$/i', (string) $asesor['pk'], $m)) {
+            if (!isset($asesor['id']) && isset($asesor['pk']) && preg_match('/^ase#(\d+)$/i', (string) $asesor['pk'], $m)) {
                 $asesor['id'] = (int) $m[1];
             }
             if (!isset($asesor['pk']) && isset($asesor['id'])) {
-                $asesor['pk'] = sprintf('ASE#%d', (int) $asesor['id']);
+                $asesor['pk'] = sprintf('ase#%d', (int) $asesor['id']);
             }
             return $asesor;
         }
@@ -1008,7 +1008,7 @@ class InquilinoController
         $asesorId = null;
         if (isset($profile['asesor_id']) && (int) $profile['asesor_id'] > 0) {
             $asesorId = (int) $profile['asesor_id'];
-        } elseif (!empty($profile['asesor_pk']) && preg_match('/^ASE#(\d+)$/i', (string) $profile['asesor_pk'], $m)) {
+        } elseif (!empty($profile['asesor_pk']) && preg_match('/^ase#(\d+)$/i', (string) $profile['asesor_pk'], $m)) {
             $asesorId = (int) $m[1];
         }
 
@@ -1022,7 +1022,7 @@ class InquilinoController
         }
 
         if (!isset($asesorData['pk'])) {
-            $asesorData['pk'] = sprintf('ASE#%d', (int) ($asesorData['id'] ?? $asesorId));
+            $asesorData['pk'] = sprintf('ase#%d', (int) ($asesorData['id'] ?? $asesorId));
         }
 
         return $asesorData;

--- a/Backend/admin/Models/ArrendadorModel.php
+++ b/Backend/admin/Models/ArrendadorModel.php
@@ -305,7 +305,7 @@ class ArrendadorModel
             'ExpressionAttributeValues' => [
                 ':pk'     => ['S' => 'arr#'],
                 ':sk'     => ['S' => 'profile'],
-                ':asesor' => ['S' => $asesorId] // Ej: ASE#1
+                ':asesor' => ['S' => $asesorId] // Ej: ase#1
             ]
         ]);
 

--- a/Backend/admin/Models/AsesorModel.php
+++ b/Backend/admin/Models/AsesorModel.php
@@ -15,7 +15,7 @@ use RuntimeException;
 /**
  * Modelo de Asesores basado en DynamoDB.
  *
- * pk: ASE#<id>
+ * pk: ase#<id>
  * sk: profile
  *
  * Atributos principales
@@ -23,7 +23,6 @@ use RuntimeException;
  * - nombre_asesor (S)
  * - email (S)
  * - celular (S, opcional)
- * - telefono (S, opcional)
  * - fecha_registro (S, ISO8601)
  * - inquilinos_id (SS) → lista de PKs de inquilinos asociados
  */
@@ -60,7 +59,7 @@ class AsesorModel
     {
         if (isset($item['id'])) {
             $item['id'] = (int) $item['id'];
-        } elseif (!empty($item['pk']) && preg_match('/^ASE#(\d+)$/i', (string) $item['pk'], $matches)) {
+        } elseif (!empty($item['pk']) && preg_match('/^ase#(\d+)$/i', (string) $item['pk'], $matches)) {
             $item['id'] = (int) $matches[1];
         }
 
@@ -167,7 +166,7 @@ class AsesorModel
         $filtered = array_values(array_filter(
             $asesores,
             static function (array $asesor) use ($needle): bool {
-                foreach (['nombre_asesor', 'email', 'celular', 'telefono'] as $field) {
+                foreach (['nombre_asesor', 'email', 'celular'] as $field) {
                     $value = mb_strtolower((string) ($asesor[$field] ?? ''), 'UTF-8');
                     if ($value !== '' && mb_strpos($value, $needle, 0, 'UTF-8') !== false) {
                         return true;
@@ -193,8 +192,6 @@ class AsesorModel
         $nombre = trim((string) ($data['nombre_asesor'] ?? ''));
         $email  = trim((string) ($data['email'] ?? ''));
         $cel    = trim((string) ($data['celular'] ?? ''));
-        $tel    = trim((string) ($data['telefono'] ?? ''));
-
         if ($nombre === '' || $email === '') {
             throw new RuntimeException('Nombre y email son obligatorios.');
         }
@@ -203,36 +200,43 @@ class AsesorModel
             throw new RuntimeException('El nombre del asesor ya existe.');
         }
 
-        $id = $this->nextId();
-        $pk = $this->buildPk($id);
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $id = $this->nextId();
 
-        $item = [
-            'pk'             => ['S' => $pk],
-            'sk'             => ['S' => self::PROFILE_SK],
-            'id'             => ['N' => (string) $id],
-            'nombre_asesor'  => ['S' => $nombre],
-            'email'          => ['S' => $email],
-            'fecha_registro' => ['S' => date('c')],
-        ];
+            if ($this->find($id) !== null) {
+                continue;
+            }
 
-        if ($cel !== '') {
-            $item['celular'] = ['S' => $cel];
+            $pk = $this->buildPk($id);
+            $item = [
+                'pk'             => ['S' => $pk],
+                'sk'             => ['S' => self::PROFILE_SK],
+                'id'             => ['N' => (string) $id],
+                'nombre_asesor'  => ['S' => $nombre],
+                'email'          => ['S' => $email],
+                'fecha_registro' => ['S' => date('c')],
+            ];
+
+            if ($cel !== '') {
+                $item['celular'] = ['S' => $cel];
+            }
+
+            try {
+                $this->client->putItem([
+                    'TableName'           => $this->table,
+                    'Item'                => $item,
+                    'ConditionExpression' => 'attribute_not_exists(pk) AND attribute_not_exists(sk)',
+                ]);
+
+                return $id;
+            } catch (DynamoDbException $e) {
+                if ($e->getAwsErrorCode() !== 'ConditionalCheckFailedException') {
+                    throw new RuntimeException('No se pudo guardar el asesor: ' . $e->getMessage(), 0, $e);
+                }
+            }
         }
-        if ($tel !== '') {
-            $item['telefono'] = ['S' => $tel];
-        }
 
-        try {
-            $this->client->putItem([
-                'TableName'           => $this->table,
-                'Item'                => $item,
-                'ConditionExpression' => 'attribute_not_exists(pk)',
-            ]);
-        } catch (DynamoDbException $e) {
-            throw new RuntimeException('No se pudo guardar el asesor: ' . $e->getMessage(), 0, $e);
-        }
-
-        return $id;
+        throw new RuntimeException('No se pudo generar un identificador único para el asesor.');
     }
 
     /**
@@ -243,8 +247,6 @@ class AsesorModel
         $nombre = trim((string) ($data['nombre_asesor'] ?? ''));
         $email  = trim((string) ($data['email'] ?? ''));
         $cel    = trim((string) ($data['celular'] ?? ''));
-        $tel    = trim((string) ($data['telefono'] ?? ''));
-
         if ($nombre === '' || $email === '') {
             throw new RuntimeException('Nombre y email son obligatorios.');
         }
@@ -254,7 +256,7 @@ class AsesorModel
         }
 
         $setParts = ['#nombre = :nombre', '#email = :email'];
-        $remove   = [];
+        $remove   = ['#telefono'];
         $values   = [
             ':nombre' => ['S' => $nombre],
             ':email'  => ['S' => $email],
@@ -262,6 +264,7 @@ class AsesorModel
         $names    = [
             '#nombre' => 'nombre_asesor',
             '#email'  => 'email',
+            '#telefono' => 'telefono',
         ];
 
         if ($cel !== '') {
@@ -271,15 +274,6 @@ class AsesorModel
         } else {
             $remove[]           = '#celular';
             $names['#celular']  = 'celular';
-        }
-
-        if ($tel !== '') {
-            $setParts[]          = '#telefono = :telefono';
-            $values[':telefono'] = ['S' => $tel];
-            $names['#telefono']  = 'telefono';
-        } else {
-            $remove[]            = '#telefono';
-            $names['#telefono']  = 'telefono';
         }
 
         $expressions = [];

--- a/Backend/admin/Models/InquilinoModel.php
+++ b/Backend/admin/Models/InquilinoModel.php
@@ -1220,7 +1220,7 @@ class InquilinoModel
             throw new \RuntimeException('Asesor inválido.');
         }
 
-        $nuevoPk = sprintf('ASE#%d', $nuevoId);
+        $nuevoPk = sprintf('ase#%d', $nuevoId);
 
         $asesorPayload = [
             'id'            => $nuevoId,
@@ -1228,7 +1228,6 @@ class InquilinoModel
             'nombre_asesor' => (string) ($asesorData['nombre_asesor'] ?? ''),
             'email'         => (string) ($asesorData['email'] ?? ''),
             'celular'       => (string) ($asesorData['celular'] ?? ''),
-            'telefono'      => (string) ($asesorData['telefono'] ?? ''),
         ];
 
         $prevAsesorId = null;
@@ -1236,11 +1235,11 @@ class InquilinoModel
             $prevAsesorId = (int)$profile['asesor_id'];
         } elseif (!empty($profile['asesor']['id'])) {
             $prevAsesorId = (int)$profile['asesor']['id'];
-        } elseif (!empty($profile['asesor_pk']) && preg_match('/^ASE#(\d+)$/i', (string)$profile['asesor_pk'], $m)) {
+        } elseif (!empty($profile['asesor_pk']) && preg_match('/^ase#(\d+)$/i', (string)$profile['asesor_pk'], $m)) {
             $prevAsesorId = (int)$m[1];
         }
 
-        $prevAsesorPk = $prevAsesorId ? sprintf('ASE#%d', $prevAsesorId) : null;
+        $prevAsesorPk = $prevAsesorId ? sprintf('ase#%d', $prevAsesorId) : null;
 
         $this->client->updateItem([
             'TableName' => $this->table,
@@ -1393,7 +1392,7 @@ class InquilinoModel
                 'id'      => $row['id'],
                 'nombre'  => $row['nombre'],
                 'email'   => $row['email'],
-                'telefono'=> $row['celular'],
+                'celular' => $row['celular'] ?? '',
                 'tipo'    => $row['tipo'] ?? 'inquilino',
             ];
         }, $rows);

--- a/Backend/admin/Views/asesores/index.php
+++ b/Backend/admin/Views/asesores/index.php
@@ -59,23 +59,13 @@
                     required
                     class="w-full rounded-lg px-4 py-3 bg-[#232336] text-indigo-100 border border-indigo-800 placeholder-indigo-400 focus:ring-2 focus:ring-indigo-600 focus:outline-none" />
             </div>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                    <label for="asesor-celular" class="block text-sm font-semibold text-indigo-200 mb-1">Celular</label>
-                    <input
-                        id="asesor-celular"
-                        type="text"
-                        name="celular"
-                        class="w-full rounded-lg px-4 py-3 bg-[#232336] text-indigo-100 border border-indigo-800 placeholder-indigo-400 focus:ring-2 focus:ring-indigo-600 focus:outline-none" />
-                </div>
-                <div>
-                    <label for="asesor-telefono" class="block text-sm font-semibold text-indigo-200 mb-1">Teléfono</label>
-                    <input
-                        id="asesor-telefono"
-                        type="text"
-                        name="telefono"
-                        class="w-full rounded-lg px-4 py-3 bg-[#232336] text-indigo-100 border border-indigo-800 placeholder-indigo-400 focus:ring-2 focus:ring-indigo-600 focus:outline-none" />
-                </div>
+            <div>
+                <label for="asesor-celular" class="block text-sm font-semibold text-indigo-200 mb-1">Celular</label>
+                <input
+                    id="asesor-celular"
+                    type="text"
+                    name="celular"
+                    class="w-full rounded-lg px-4 py-3 bg-[#232336] text-indigo-100 border border-indigo-800 placeholder-indigo-400 focus:ring-2 focus:ring-indigo-600 focus:outline-none" />
             </div>
             <div class="flex justify-end gap-3 pt-2">
                 <button
@@ -126,7 +116,6 @@
             const name = escapeHtml(asesor.nombre_asesor || 'Sin nombre');
             const email = escapeHtml(asesor.email || '');
             const celular = escapeHtml(asesor.celular || '—');
-            const telefono = escapeHtml(asesor.telefono || '—');
             const inquilinos = Array.isArray(asesor.inquilinos_id) ? asesor.inquilinos_id.length : 0;
 
             return `
@@ -136,7 +125,6 @@
                             <h3 class="text-xl font-bold text-white mb-1">${name}</h3>
                             <p class="text-sm text-indigo-200">${email}</p>
                             <p class="text-xs text-indigo-200/70 mt-1">Celular: ${celular}</p>
-                            <p class="text-xs text-indigo-200/70">Teléfono: ${telefono}</p>
                         </div>
                         <div class="flex flex-col gap-2">
                             <button
@@ -168,9 +156,7 @@
         const nombre = document.getElementById('asesor-nombre');
         const email = document.getElementById('asesor-email');
         const celular = document.getElementById('asesor-celular');
-        const telefono = document.getElementById('asesor-telefono');
-
-        if (!modal || !title || !idField || !nombre || !email || !celular || !telefono) {
+        if (!modal || !title || !idField || !nombre || !email || !celular) {
             return;
         }
 
@@ -181,14 +167,12 @@
             nombre.value = asesor.nombre_asesor ?? '';
             email.value = asesor.email ?? '';
             celular.value = asesor.celular ?? '';
-            telefono.value = asesor.telefono ?? '';
         } else {
             title.textContent = 'Nuevo Asesor';
             idField.value = '';
             nombre.value = '';
             email.value = '';
             celular.value = '';
-            telefono.value = '';
         }
 
         modal.classList.remove('hidden');

--- a/Backend/admin/Views/inquilino/detalle.php
+++ b/Backend/admin/Views/inquilino/detalle.php
@@ -1550,10 +1550,6 @@ $selfieUrl    = $selfieUrl ?? null;
                     <?php endif; ?>
                 </span>
             </div>
-            <div>
-                <span class="font-semibold text-fuchsia-100">Teléfono:</span>
-                <span class="block text-white/90"><?= $a['telefono'] ?? 'N/A' ?></span>
-            </div>
         </div>
 
         <!-- Formulario edición (oculto) -->


### PR DESCRIPTION
## Summary
- normalize the asesor key handling to use the `ase#` prefix and retry ID assignment when Dynamo reports a conflicting item
- remove the obsolete teléfono field from asesor forms, views, and persisted payloads so only celular remains
- keep downstream consumers in sync by updating inquilino data mappings, AI responses, and related comments

## Testing
- php -l Backend/admin/Models/AsesorModel.php
- php -l Backend/admin/Controllers/AsesorController.php
- php -l Backend/admin/Models/InquilinoModel.php
- php -l Backend/admin/Controllers/IAController.php
- php -l Backend/admin/Controllers/InquilinoController.php
- php -l Backend/admin/Views/asesores/index.php
- php -l Backend/admin/Views/inquilino/detalle.php
- php -l Backend/admin/Models/ArrendadorModel.php

------
https://chatgpt.com/codex/tasks/task_e_68cc98f9b99883239cbb3d0ea90a1219