### PR TITLE
Update inmueble routes to use composite keys

### DIFF
--- a/Backend/admin/Controllers/InmuebleController.php
+++ b/Backend/admin/Controllers/InmuebleController.php
@@ -78,8 +78,18 @@ class InmuebleController
     /**
      * Ver detalle de un inmueble
      */
-    public function ver(int $id): void
+    public function ver(string $pk, string $sk): void
     {
+        $id = $this->model->obtenerIdPorLlaves($pk, $sk);
+        if ($id === null) {
+            http_response_code(404);
+            $title = 'No encontrado';
+            $headerTitle = 'Recurso no encontrado';
+            $contentView = __DIR__ . '/../Views/404.php';
+            include __DIR__ . '/../Views/layouts/main.php';
+            return;
+        }
+
         $inmueble = $this->model->obtenerPorId($id);
         if (!$inmueble) {
             http_response_code(404);
@@ -209,8 +219,14 @@ class InmuebleController
     /**
      * Formulario de edición
      */
-    public function editar(int $id): void
+    public function editar(string $pk, string $sk): void
     {
+        $id = $this->model->obtenerIdPorLlaves($pk, $sk);
+        if ($id === null) {
+            header('Location: ' . getBaseUrl() . '/inmuebles');
+            exit;
+        }
+
         $inmueble = $this->model->obtenerPorId($id);
         if (!$inmueble) {
             header('Location: ' . getBaseUrl() . '/inmuebles');
@@ -285,7 +301,7 @@ class InmuebleController
     /**
      * Eliminar inmueble (JSON, Dynamo)
      */
-    public function delete(): void
+    public function delete(?string $pkRoute = null, ?string $skRoute = null): void
     {
 
         header('Content-Type: application/json; charset=utf-8');
@@ -296,8 +312,8 @@ class InmuebleController
             return;
         }
 
-        $pk = NormalizadoHelper::lower($_POST['pk'] ?? '');
-        $sk = NormalizadoHelper::lower($_POST['sk'] ?? '');
+        $pk = $pkRoute !== null ? NormalizadoHelper::lower($pkRoute) : NormalizadoHelper::lower($_POST['pk'] ?? '');
+        $sk = $skRoute !== null ? NormalizadoHelper::lower($skRoute) : NormalizadoHelper::lower($_POST['sk'] ?? '');
 
         if (!$pk || !$sk) {
             http_response_code(400);

--- a/Backend/admin/Models/InmueblesModel.php
+++ b/Backend/admin/Models/InmueblesModel.php
@@ -125,6 +125,20 @@ class InmuebleModel extends Database
         return $row ?: null;
     }
 
+    public function obtenerIdPorLlaves(string $pk, string $sk): ?int
+    {
+        $sql = 'SELECT id FROM inmuebles WHERE pk = :pk AND sk = :sk LIMIT 1';
+        $stmt = $this->getConnection()->prepare($sql);
+        $stmt->execute([
+            ':pk' => $pk,
+            ':sk' => $sk,
+        ]);
+
+        $id = $stmt->fetchColumn();
+
+        return $id !== false ? (int) $id : null;
+    }
+
     public function crear(array $data): bool
     {
         /**

--- a/Backend/admin/Views/inmuebles/detalle.php
+++ b/Backend/admin/Views/inmuebles/detalle.php
@@ -16,7 +16,14 @@
         </div>
         <div class="flex justify-center gap-3 pt-4">
             <a href="<?= $baseUrl ?>/inmuebles" class="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white">Regresar</a>
-            <a href="<?= $baseUrl ?>/inmuebles/editar/<?= $inmueble['id'] ?>" class="px-4 py-2 rounded-lg bg-pink-600 hover:bg-pink-500 text-white">Editar</a>
+            <?php
+                $pk = (string)($inmueble['pk'] ?? '');
+                $sk = (string)($inmueble['sk'] ?? '');
+            ?>
+            <a
+                href="<?= $baseUrl ?>/inmuebles/editar/<?= rawurlencode($pk) ?>/<?= rawurlencode($sk) ?>"
+                class="px-4 py-2 rounded-lg bg-pink-600 hover:bg-pink-500 text-white"
+            >Editar</a>
         </div>
     </div>
 </div>

--- a/Backend/admin/Views/inmuebles/index.php
+++ b/Backend/admin/Views/inmuebles/index.php
@@ -32,7 +32,16 @@
         </thead>
         <tbody class="divide-y divide-gray-700 text-indigo-100">
             <?php foreach ($inmuebles as $inm): ?>
-                <tr id="row-<?= $inm['id'] ?>">
+                <?php
+                    $pk = (string)($inm['pk'] ?? '');
+                    $sk = (string)($inm['sk'] ?? '');
+                    $rowId = sprintf('row-%s-%s', $pk, $sk);
+                ?>
+                <tr
+                    id="<?= htmlspecialchars($rowId) ?>"
+                    data-pk="<?= htmlspecialchars($pk) ?>"
+                    data-sk="<?= htmlspecialchars($sk) ?>"
+                >
                     <td class="px-4 py-2 whitespace-nowrap"><?= htmlspecialchars($inm['direccion_inmueble']) ?></td>
                     <td class="px-4 py-2 text-center"><?= htmlspecialchars($inm['tipo']) ?></td>
                     <td class="px-4 py-2 text-center">$<?= htmlspecialchars($inm['renta']) ?></td>
@@ -43,17 +52,30 @@
                     </td>
                     <td class="px-4 py-2 text-center">
                         <div class="flex gap-2 justify-center">
-                            <a href="<?= $baseUrl ?>/inmuebles/<?= $inm['id'] ?>" class="text-green-400 hover:text-green-300" title="Ver">
+                            <a
+                                href="<?= $baseUrl ?>/inmuebles/<?= rawurlencode($pk) ?>/<?= rawurlencode($sk) ?>"
+                                class="text-green-400 hover:text-green-300"
+                                title="Ver"
+                            >
                                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                     <path d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" />
                                 </svg>
                             </a>
-                            <a href="<?= $baseUrl ?>/inmuebles/editar/<?= $inm['id'] ?>" class="text-pink-400 hover:text-pink-300" title="Editar">
+                            <a
+                                href="<?= $baseUrl ?>/inmuebles/editar/<?= rawurlencode($pk) ?>/<?= rawurlencode($sk) ?>"
+                                class="text-pink-400 hover:text-pink-300"
+                                title="Editar"
+                            >
                                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                     <path d="M11 5H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2v-5M18.5 2.5a2.121 2.121 0 113 3L12 15l-4 1 1-4 9.5-9.5z" />
                                 </svg>
                             </a>
-                            <button data-id="<?= $inm['id'] ?>" class="btn-eliminar text-red-400 hover:text-red-300" title="Eliminar">
+                            <button
+                                data-pk="<?= htmlspecialchars($pk) ?>"
+                                data-sk="<?= htmlspecialchars($sk) ?>"
+                                class="btn-eliminar text-red-400 hover:text-red-300"
+                                title="Eliminar"
+                            >
                                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                     <path d="M6 18L18 6M6 6l12 12" />
                                 </svg>
@@ -143,7 +165,12 @@
 <script>
     document.querySelectorAll('.btn-eliminar').forEach(btn => {
         btn.addEventListener('click', () => {
-            const id = btn.dataset.id;
+            const { pk, sk } = btn.dataset;
+            if (!pk || !sk) {
+                Swal.fire('Error', 'Identificador del inmueble no disponible', 'error');
+                return;
+            }
+            const rowId = `row-${pk}-${sk}`;
             Swal.fire({
                 title: '¿Eliminar inmueble?',
                 icon: 'warning',
@@ -158,12 +185,15 @@
                     fetch('<?= $baseUrl ?>/inmuebles/delete', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                        body: 'id=' + id
+                        body: `pk=${encodeURIComponent(pk)}&sk=${encodeURIComponent(sk)}`
                     })
                     .then(r => r.json())
                     .then(data => {
                         if (data.ok) {
-                            document.getElementById('row-' + id).remove();
+                            const row = document.getElementById(rowId);
+                            if (row) {
+                                row.remove();
+                            }
                             Swal.fire('Eliminado', '', 'success');
                         } else {
                             Swal.fire('Error', 'No se pudo eliminar', 'error');

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -231,9 +231,9 @@ switch (true) {
         exit;
         break;
 
-    case preg_match('#^/inmuebles/editar/(\d+)$#', $uri, $m):
+    case preg_match('#^/inmuebles/editar/([^/]+)/([^/]+)$#', $uri, $m):
         require __DIR__ . '/Controllers/InmuebleController.php';
-        (new \App\Controllers\InmuebleController())->editar((int)$m[1]);
+        (new \App\Controllers\InmuebleController())->editar(rawurldecode($m[1]), rawurldecode($m[2]));
         exit;
         break;
 
@@ -261,9 +261,14 @@ switch (true) {
         exit;
         break;
 
-    case preg_match('#^/inmuebles/(\d+)$#', $uri, $m):
+    case preg_match('#^/inmuebles/([^/]+)/([^/]+)$#', $uri, $m):
         require __DIR__ . '/Controllers/InmuebleController.php';
-        (new \App\Controllers\InmuebleController())->ver((int)$m[1]);
+        (new \App\Controllers\InmuebleController())->ver(rawurldecode($m[1]), rawurldecode($m[2]));
+        exit;
+        break;
+    case preg_match('#^/inmuebles/delete/([^/]+)/([^/]+)$#', $uri, $m) && $_SERVER['REQUEST_METHOD'] === 'POST':
+        require __DIR__ . '/Controllers/InmuebleController.php';
+        (new \App\Controllers\InmuebleController())->delete(rawurldecode($m[1]), rawurldecode($m[2]));
         exit;
         break;
 


### PR DESCRIPTION
## Summary
- expose inmueble listings with pk/sk attributes instead of numeric ids
- update delete flow to post composite keys and accept optional route params
- adjust router and controller to resolve pk/sk pairs back to existing data

## Testing
- php -l Backend/admin/Views/inmuebles/index.php
- php -l Backend/admin/Controllers/InmuebleController.php
- php -l Backend/admin/Models/InmueblesModel.php
- php -l Backend/admin/Views/inmuebles/detalle.php
- php -l Backend/admin/router.php

------
https://chatgpt.com/codex/tasks/task_e_68cce82e1ce88323b17f9a27ec96d7f6