### PR TITLE
Normaliza payload de inmuebles para Dynamo

### DIFF
--- a/Backend/admin/Controllers/InmuebleController.php
+++ b/Backend/admin/Controllers/InmuebleController.php
@@ -241,10 +241,13 @@ class InmuebleController
         }
 
         try {
-            $data = $this->buildInmuebleDataFromPost();
+            $data = $this->buildDynamoInmueblePayload();
 
             $ok = $this->model->crear($data);
             echo json_encode(['ok' => (bool)$ok]);
+        } catch (\InvalidArgumentException $e) {
+            http_response_code(422);
+            echo json_encode(['ok' => false, 'mensaje' => $e->getMessage()]);
         } catch (\Throwable $e) {
             http_response_code(500);
             echo json_encode(['ok' => false, 'mensaje' => 'Error al crear inmueble', 'error' => $e->getMessage()]);
@@ -264,18 +267,17 @@ class InmuebleController
             return;
         }
 
-        $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
-        if ($id <= 0) {
-            http_response_code(400);
-            echo json_encode(['ok' => false, 'mensaje' => 'ID inválido']);
-            return;
-        }
-
         try {
-            $data = $this->buildInmuebleDataFromPost(/* isUpdate */true);
+            $data = $this->buildDynamoInmueblePayload(true);
+            $pk = $data['pk'];
+            $sk = $data['sk'];
+            unset($data['sk']);
 
-            $ok = $this->model->actualizar($id, $data);
+            $ok = $this->model->actualizarPorPkSk($pk, $sk, $data);
             echo json_encode(['ok' => (bool)$ok]);
+        } catch (\InvalidArgumentException $e) {
+            http_response_code(422);
+            echo json_encode(['ok' => false, 'mensaje' => $e->getMessage()]);
         } catch (\Throwable $e) {
             http_response_code(500);
             echo json_encode(['ok' => false, 'mensaje' => 'Error al actualizar inmueble', 'error' => $e->getMessage()]);
@@ -363,45 +365,95 @@ class InmuebleController
      * @param bool $isUpdate Si es true, procesa 'estacionamiento' aceptando 0/1 directos además de checkbox
      * @return array<string, string|int>
      */
-    private function buildInmuebleDataFromPost(bool $isUpdate = false): array
+    private function buildDynamoInmueblePayload(bool $isUpdate = false): array
     {
-        // IDs seguros
-        $idArrendador = isset($_POST['id_arrendador']) ? (int)$_POST['id_arrendador'] : 0;
-        $idAsesor     = isset($_POST['id_asesor']) ? (int)$_POST['id_asesor'] : 0;
-
-        // Estacionamiento:
-        // - En crear (checkbox): isset → 1/0
-        // - En update aceptamos '0'/'1' o checkbox
-        $estacionamiento = 0;
-        if ($isUpdate) {
-            if (isset($_POST['estacionamiento'])) {
-                // Si viene de input hidden/select
-                $val = trim((string)$_POST['estacionamiento']);
-                $estacionamiento = (int)($val === '1' || $val === 'SI' || $val === 'true' || $val === 'on' || $val === 'yes');
-            } else {
-                $estacionamiento = 0;
-            }
-        } else {
-            $estacionamiento = isset($_POST['estacionamiento']) ? 1 : 0;
+        $pkInput = trim((string)($_POST['pk'] ?? $_POST['arrendador_pk'] ?? $_POST['id_arrendador'] ?? ''));
+        if ($pkInput === '') {
+            throw new \InvalidArgumentException('Debe seleccionar un arrendador');
         }
 
-        // Mascotas: solo SI/NO
-        $mascotasRaw = strtoupper(trim((string)($_POST['mascotas'] ?? 'NO')));
-        $mascotas = ($mascotasRaw === 'SI') ? 'SI' : 'NO';
+        if (ctype_digit($pkInput)) {
+            $pkInput = 'arr#' . $pkInput;
+        }
 
-        return [
-            'id_arrendador'       => $idArrendador,
-            'id_asesor'           => $idAsesor,
-            'direccion_inmueble'  => trim((string)($_POST['direccion_inmueble'] ?? '')),
-            'tipo'                => trim((string)($_POST['tipo'] ?? '')),
-            'renta'               => $this->normalizarMonto((string)($_POST['renta'] ?? '0')),
-            'mantenimiento'       => trim((string)($_POST['mantenimiento'] ?? '')),
-            'monto_mantenimiento' => $this->normalizarMonto((string)($_POST['monto_mantenimiento'] ?? '0')),
-            'deposito'            => $this->normalizarMonto((string)($_POST['deposito'] ?? '0')),
-            'estacionamiento'     => $estacionamiento, // 1 | 0
-            'mascotas'            => $mascotas,        // 'SI' | 'NO'
-            'comentarios'         => trim((string)($_POST['comentarios'] ?? '')),
+        $pk = NormalizadoHelper::lower($pkInput);
+        if ($pk === '') {
+            throw new \InvalidArgumentException('Identificador de arrendador inválido');
+        }
+
+        $sk = '';
+        if ($isUpdate) {
+            $skInput = trim((string)($_POST['sk'] ?? ''));
+            if ($skInput === '') {
+                throw new \InvalidArgumentException('Identificador del inmueble requerido');
+            }
+            $sk = NormalizadoHelper::lower($skInput);
+        }
+
+        $direccion = NormalizadoHelper::lower(trim((string)($_POST['direccion_inmueble'] ?? '')));
+        $tipo = NormalizadoHelper::lower(trim((string)($_POST['tipo'] ?? '')));
+        $rentaRaw = (string)($_POST['renta'] ?? '');
+        $renta = $this->normalizarMonto($rentaRaw);
+
+        if ($direccion === '' || $tipo === '' || trim($rentaRaw) === '') {
+            throw new \InvalidArgumentException('Faltan datos obligatorios del inmueble');
+        }
+
+        $mantenimientoRaw = NormalizadoHelper::lower(trim((string)($_POST['mantenimiento'] ?? 'no')));
+        $mantenimiento = $mantenimientoRaw === 'si' ? 'si' : 'no';
+
+        $montoMantenimiento = $this->normalizarMonto((string)($_POST['monto_mantenimiento'] ?? '0'));
+        $deposito = $this->normalizarMonto((string)($_POST['deposito'] ?? '0'));
+
+        $estacionamientoVal = $_POST['estacionamiento'] ?? 0;
+        if (is_array($estacionamientoVal)) {
+            $estacionamientoVal = reset($estacionamientoVal);
+        }
+        $estacionamiento = max(0, (int)$estacionamientoVal);
+
+        $mascotasRaw = strtoupper(trim((string)($_POST['mascotas'] ?? 'NO')));
+        $mascotas = $mascotasRaw === 'SI' ? 'SI' : 'NO';
+
+        $comentarios = NormalizadoHelper::lower(trim((string)($_POST['comentarios'] ?? '')));
+
+        $asesorInput = trim((string)($_POST['asesor_pk'] ?? ($_POST['id_asesor'] ?? '')));
+        $asesor = '';
+        if ($asesorInput !== '') {
+            if (ctype_digit($asesorInput)) {
+                $asesorInput = 'ase#' . $asesorInput;
+            }
+            $asesor = NormalizadoHelper::lower($asesorInput);
+        }
+
+        if ($asesor === '' && $pk !== '') {
+            $profile = $this->arrendadorModel->obtenerProfilePorPk($pk);
+            if ($profile && !empty($profile['asesor'])) {
+                $asesor = NormalizadoHelper::lower((string)$profile['asesor']);
+            }
+        }
+
+        $data = [
+            'pk'                  => $pk,
+            'tipo'                => $tipo,
+            'direccion_inmueble'  => $direccion,
+            'renta'               => $renta,
+            'mantenimiento'       => $mantenimiento,
+            'monto_mantenimiento' => $montoMantenimiento,
+            'deposito'            => $deposito,
+            'estacionamiento'     => $estacionamiento,
+            'mascotas'            => $mascotas,
+            'comentarios'         => $comentarios,
         ];
+
+        if ($asesor !== '') {
+            $data['asesor'] = $asesor;
+        }
+
+        if ($isUpdate) {
+            $data['sk'] = $sk;
+        }
+
+        return $data;
     }
 
     /**

--- a/Backend/admin/Models/ArrendadorModel.php
+++ b/Backend/admin/Models/ArrendadorModel.php
@@ -439,4 +439,31 @@ class ArrendadorModel
         ];
     }
 
+    public function obtenerProfilePorPk(string $pk): ?array
+    {
+        $pk = NormalizadoHelper::lower(trim($pk));
+        if ($pk === '') {
+            return null;
+        }
+
+        try {
+            $result = $this->client->getItem([
+                'TableName' => $this->table,
+                'Key'       => [
+                    'pk' => ['S' => $pk],
+                    'sk' => ['S' => 'profile']
+                ]
+            ]);
+
+            if (empty($result['Item'])) {
+                return null;
+            }
+
+            return $this->marshaler->unmarshalItem($result['Item']);
+        } catch (\Throwable $e) {
+            error_log('❌ Error obteniendo perfil de arrendador: ' . $e->getMessage());
+            return null;
+        }
+    }
+
 }

--- a/Backend/admin/Models/InmueblesModel.php
+++ b/Backend/admin/Models/InmueblesModel.php
@@ -143,20 +143,24 @@ class InmuebleModel extends Database
             'renta'              => ['N' => (string) $data['renta']],
             'mantenimiento'      => ['S' => $data['mantenimiento']],
             'estacionamiento'    => ['N' => (string) $data['estacionamiento']],
-            'mascotas'           => ['S' => strtoupper($data['mascotas'])],
+            'mascotas'           => ['S' => strtoupper((string) $data['mascotas'])],
             'fecha_registro'     => ['S' => date('Y-m-d H:i:s')],
         ];
 
-        if ($data['monto_mantenimiento'] !== '' && is_numeric($data['monto_mantenimiento'])) {
+        if (isset($data['monto_mantenimiento']) && $data['monto_mantenimiento'] !== null && $data['monto_mantenimiento'] !== '') {
             $item['monto_mantenimiento'] = ['N' => (string) $data['monto_mantenimiento']];
         }
 
-        if (!empty($data['deposito'])) {
-            $item['deposito'] = ['S' => $data['deposito']];
+        if (isset($data['deposito']) && $data['deposito'] !== null && $data['deposito'] !== '') {
+            $item['deposito'] = ['N' => (string) $data['deposito']];
         }
 
         if (!empty($data['comentarios'])) {
             $item['comentarios'] = ['S' => $data['comentarios']];
+        }
+
+        if (!empty($data['asesor'])) {
+            $item['asesor'] = ['S' => $data['asesor']];
         }
 
         try {
@@ -189,36 +193,80 @@ class InmuebleModel extends Database
 
 
 
-    public function actualizar(int $id, array $data): bool
+    public function actualizarPorPkSk(string $pk, string $sk, array $data): bool
     {
-        $sql = "UPDATE inmuebles SET
-                    id_arrendador = :id_arrendador,
-                    id_asesor = :id_asesor,
-                    direccion_inmueble = :direccion_inmueble,
-                    tipo = :tipo,
-                    renta = :renta,
-                    mantenimiento = :mantenimiento,
-                    monto_mantenimiento = :monto_mantenimiento,
-                    deposito = :deposito,
-                    estacionamiento = :estacionamiento,
-                    mascotas = :mascotas,
-                    comentarios = :comentarios
-                WHERE id = :id";
-        $stmt = $this->getConnection()->prepare($sql);
-        return $stmt->execute([
-            ':id_arrendador'       => $data['id_arrendador'],
-            ':id_asesor'           => $data['id_asesor'],
-            ':direccion_inmueble'  => $data['direccion_inmueble'],
-            ':tipo'                => $data['tipo'],
-            ':renta'               => $data['renta'],
-            ':mantenimiento'       => $data['mantenimiento'],
-            ':monto_mantenimiento' => $data['monto_mantenimiento'],
-            ':deposito'            => $data['deposito'],
-            ':estacionamiento'     => (int) !empty($data['estacionamiento']),
-            ':mascotas'            => $data['mascotas'],
-            ':comentarios'         => $data['comentarios'] ?? null,
-            ':id'                  => $id,
-        ]);
+        try {
+            $setParts = [
+                'tipo = :tipo',
+                'direccion_inmueble = :direccion',
+                'renta = :renta',
+                'mantenimiento = :mantenimiento',
+                'estacionamiento = :estacionamiento',
+                'mascotas = :mascotas',
+            ];
+
+            $values = [
+                ':tipo'           => ['S' => (string) $data['tipo']],
+                ':direccion'      => ['S' => (string) $data['direccion_inmueble']],
+                ':renta'          => ['N' => (string) $data['renta']],
+                ':mantenimiento'  => ['S' => (string) $data['mantenimiento']],
+                ':estacionamiento'=> ['N' => (string) (int) $data['estacionamiento']],
+                ':mascotas'       => ['S' => strtoupper((string) $data['mascotas'])],
+            ];
+
+            $remove = [];
+
+            if (isset($data['monto_mantenimiento']) && $data['monto_mantenimiento'] !== null && $data['monto_mantenimiento'] !== '') {
+                $setParts[] = 'monto_mantenimiento = :monto_mantenimiento';
+                $values[':monto_mantenimiento'] = ['N' => (string) $data['monto_mantenimiento']];
+            } else {
+                $remove[] = 'monto_mantenimiento';
+            }
+
+            if (isset($data['deposito']) && $data['deposito'] !== null && $data['deposito'] !== '') {
+                $setParts[] = 'deposito = :deposito';
+                $values[':deposito'] = ['N' => (string) $data['deposito']];
+            } else {
+                $remove[] = 'deposito';
+            }
+
+            if (!empty($data['comentarios'])) {
+                $setParts[] = 'comentarios = :comentarios';
+                $values[':comentarios'] = ['S' => (string) $data['comentarios']];
+            } else {
+                $remove[] = 'comentarios';
+            }
+
+            if (!empty($data['asesor'])) {
+                $setParts[] = 'asesor = :asesor';
+                $values[':asesor'] = ['S' => (string) $data['asesor']];
+            } else {
+                $remove[] = 'asesor';
+            }
+
+            $updateExpression = 'SET ' . implode(', ', $setParts);
+            $remove = array_unique(array_filter($remove));
+            if (!empty($remove)) {
+                $updateExpression .= ' REMOVE ' . implode(', ', $remove);
+            }
+
+            $params = [
+                'TableName' => $this->table,
+                'Key'       => [
+                    'pk' => ['S' => $pk],
+                    'sk' => ['S' => $sk],
+                ],
+                'UpdateExpression'          => $updateExpression,
+                'ExpressionAttributeValues' => $values,
+            ];
+
+            $this->client->updateItem($params);
+
+            return true;
+        } catch (\Throwable $e) {
+            error_log('❌ Error actualizando inmueble en Dynamo: ' . $e->getMessage());
+            return false;
+        }
     }
 
     public function eliminar(string $pk, string $sk): bool

--- a/Backend/admin/Views/inmuebles/form.php
+++ b/Backend/admin/Views/inmuebles/form.php
@@ -1,5 +1,15 @@
 <?php
 $editing = $editMode ?? false;
+$inmueble = $inmueble ?? [];
+$arrendadores = $arrendadores ?? [];
+$asesores = $asesores ?? [];
+$asesoresPorPk = [];
+foreach ($asesores as $asesor) {
+    $pk = $asesor['pk'] ?? (isset($asesor['id']) ? 'ase#' . $asesor['id'] : null);
+    if ($pk) {
+        $asesoresPorPk[strtolower($pk)] = $asesor['nombre_asesor'] ?? '';
+    }
+}
 ?>
 <div class="max-w-2xl mx-auto py-10">
     <h1 class="text-3xl font-bold text-indigo-300 mb-8"><?= $editing ? 'Editar' : 'Registrar' ?> Inmueble</h1>
@@ -7,7 +17,7 @@ $editing = $editMode ?? false;
     <form id="form-inmueble" class="bg-white/10 backdrop-blur-lg rounded-2xl shadow-2xl p-8 border border-indigo-900/20 space-y-6">
         
         <?php if ($editing): ?>
-            <input type="hidden" name="id" value="<?= $inmueble['id'] ?>">
+            <input type="hidden" name="sk" value="<?= htmlspecialchars($inmueble['sk'] ?? '') ?>">
         <?php endif; ?>
 
         <!-- Dirección -->
@@ -84,23 +94,41 @@ $editing = $editMode ?? false;
         <div class="grid md:grid-cols-2 gap-4">
             <div>
                 <label class="block text-indigo-300 mb-1">Arrendador</label>
-                <select name="id_arrendador" class="w-full rounded-lg px-4 py-2 bg-[#232336] text-indigo-100 border border-indigo-800" required>
+                <?php
+                    $currentPk = strtolower((string)($inmueble['pk'] ?? ($inmueble['arrendador_pk'] ?? '')));
+                    if ($currentPk === '' && !empty($inmueble['id_arrendador'])) {
+                        $currentPk = 'arr#' . strtolower((string)$inmueble['id_arrendador']);
+                    }
+                ?>
+                <select name="pk" id="arrendador-select" class="w-full rounded-lg px-4 py-2 bg-[#232336] text-indigo-100 border border-indigo-800" required>
                     <?php foreach ($arrendadores as $arr): ?>
-                        <option value="<?= $arr['id'] ?>" <?= ($inmueble['id_arrendador'] ?? '') == $arr['id'] ? 'selected' : '' ?>>
-                            <?= htmlspecialchars($arr['nombre_arrendador']) ?>
+                        <?php
+                            $arrPk = $arr['pk'] ?? (isset($arr['id']) ? 'arr#' . $arr['id'] : '');
+                            $arrPkLower = strtolower((string)$arrPk);
+                            $asesorPkRaw = $arr['asesor'] ?? ($arr['asesor_pk'] ?? '');
+                            $asesorPk = strtolower((string)$asesorPkRaw);
+                            $asesorNombre = $asesorPk !== '' ? ($asesoresPorPk[$asesorPk] ?? '') : '';
+                            $selected = $currentPk === $arrPkLower;
+                        ?>
+                        <option value="<?= htmlspecialchars($arrPkLower) ?>"
+                                data-asesor="<?= htmlspecialchars($asesorPk) ?>"
+                                data-asesor-nombre="<?= htmlspecialchars($asesorNombre) ?>"
+                                <?= $selected ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($arr['nombre_arrendador'] ?? '') ?>
                         </option>
                     <?php endforeach; ?>
                 </select>
             </div>
             <div>
-                <label class="block text-indigo-300 mb-1">Asesor</label>
-                <select name="id_asesor" class="w-full rounded-lg px-4 py-2 bg-[#232336] text-indigo-100 border border-indigo-800" required>
-                    <?php foreach ($asesores as $as): ?>
-                        <option value="<?= $as['id'] ?>" <?= ($inmueble['id_asesor'] ?? '') == $as['id'] ? 'selected' : '' ?>>
-                            <?= htmlspecialchars($as['nombre_asesor']) ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
+                <label class="block text-indigo-300 mb-1">Asesor asociado</label>
+                <input type="text" id="asesor-display" class="w-full rounded-lg px-4 py-2 bg-[#232336] text-indigo-300 border border-indigo-800" value="" readonly placeholder="Se asignará automáticamente">
+                <?php
+                    $asesorInicial = strtolower((string)($inmueble['asesor'] ?? ($inmueble['asesor_pk'] ?? '')));
+                    if ($asesorInicial === '' && !empty($inmueble['id_asesor'])) {
+                        $asesorInicial = 'ase#' . strtolower((string)$inmueble['id_asesor']);
+                    }
+                ?>
+                <input type="hidden" name="asesor_pk" id="asesor-pk" value="<?= htmlspecialchars($asesorInicial) ?>">
             </div>
         </div>
 
@@ -125,6 +153,29 @@ document.getElementById('form-inmueble').addEventListener('submit', function(e){
     e.preventDefault();
     const form = e.target;
     const formData = new FormData(form);
+
+    const decimalFields = ['renta', 'monto_mantenimiento', 'deposito'];
+    const toDecimalString = (value) => {
+        if (value === null || value === undefined) {
+            return '0.00';
+        }
+        const raw = String(value).trim();
+        if (raw === '') {
+            return '0.00';
+        }
+        const normalized = raw.replace(/[^0-9,.-]/g, '').replace(',', '.');
+        const number = parseFloat(normalized);
+        if (Number.isNaN(number)) {
+            return '0.00';
+        }
+        return number.toFixed(2);
+    };
+
+    decimalFields.forEach((field) => {
+        if (formData.has(field)) {
+            formData.set(field, toDecimalString(formData.get(field)));
+        }
+    });
     const action = '<?= $baseUrl ?><?= $editing ? '/inmuebles/update' : '/inmuebles/store' ?>';
     
     fetch(action, {
@@ -143,4 +194,31 @@ document.getElementById('form-inmueble').addEventListener('submit', function(e){
         Swal.fire('Error', 'Ocurrió un error inesperado', 'error');
     });
 });
+
+const arrendadorSelect = document.getElementById('arrendador-select');
+const asesorHidden = document.getElementById('asesor-pk');
+const asesorDisplay = document.getElementById('asesor-display');
+
+const syncAsesor = () => {
+    if (!arrendadorSelect) return;
+    const selected = arrendadorSelect.selectedOptions[0];
+    if (!selected) {
+        if (asesorHidden) asesorHidden.value = '';
+        if (asesorDisplay) asesorDisplay.value = '';
+        return;
+    }
+    const asesorPk = selected.dataset.asesor ?? '';
+    const asesorNombre = selected.dataset.asesorNombre ?? '';
+    if (asesorHidden) {
+        asesorHidden.value = asesorPk;
+    }
+    if (asesorDisplay) {
+        asesorDisplay.value = asesorNombre;
+    }
+};
+
+if (arrendadorSelect) {
+    arrendadorSelect.addEventListener('change', syncAsesor);
+    syncAsesor();
+}
 </script>


### PR DESCRIPTION
## Summary
- Actualicé el formulario de inmuebles para enviar la pk del arrendador, propagar el asesor asociado y formatear los montos como cadenas decimales antes del envío.
- Reemplacé la construcción del payload en el controlador con un helper que normaliza los datos en minúsculas, resuelve el asesor y prepara los campos esperados por DynamoDB.
- Ajusté el modelo para reutilizar `putItem`/`updateItem`, agregando un método `actualizarPorPkSk` y extendiendo ArrendadorModel con `obtenerProfilePorPk`.

## Testing
- php -l Backend/admin/Views/inmuebles/form.php
- php -l Backend/admin/Controllers/InmuebleController.php
- php -l Backend/admin/Models/ArrendadorModel.php
- php -l Backend/admin/Models/InmueblesModel.php

------
https://chatgpt.com/codex/tasks/task_e_68cce8217b048323b35f84ad28fefd99