### PR TITLE
Fetch arrendador inmuebles from Dynamo and update selector

### DIFF
--- a/Backend/admin/Controllers/InmuebleController.php
+++ b/Backend/admin/Controllers/InmuebleController.php
@@ -343,13 +343,24 @@ class InmuebleController
     /**
      * Devuelve inmuebles por arrendador (JSON)
      */
-    public function inmueblesPorArrendador(int $id): void
+    public function inmueblesPorArrendador(string $identificador): void
     {
         header('Content-Type: application/json');
-        $id = (int)$id;
+
+        $identificador = trim(rawurldecode($identificador));
+
+        if ($identificador === '') {
+            http_response_code(400);
+            echo json_encode(['ok' => false, 'mensaje' => 'Identificador de arrendador inválido']);
+            return;
+        }
+
+        $idOClave = ctype_digit($identificador)
+            ? (int) $identificador
+            : $identificador;
 
         try {
-            $inmuebles = $this->model->obtenerPorArrendador($id);
+            $inmuebles = $this->model->obtenerPorArrendador($idOClave);
             echo json_encode($inmuebles ?? []);
         } catch (\Throwable $e) {
             http_response_code(500);

--- a/Backend/admin/Models/AsesorModel.php
+++ b/Backend/admin/Models/AsesorModel.php
@@ -189,7 +189,7 @@ class AsesorModel
 
         $asesores = [];
 
-        foreach (array_chunk(array_values($unique), 100) as $chunk) {
+        foreach (array_chunk(array_values($unique), 25) as $chunk) {
             $keys = array_map(
                 static fn(string $pk): array => [
                     'pk' => ['S' => $pk],
@@ -217,6 +217,8 @@ class AsesorModel
                     break;
                 }
             } while (true);
+
+            usleep(250000);
         }
 
         if ($asesores === []) {

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -257,9 +257,9 @@ switch (true) {
         exit;
         break;
 
-    case preg_match('#^/inmuebles/por-arrendador/(\d+)$#', $uri, $m):
+    case preg_match('#^/inmuebles/por-arrendador/([^/]+)$#', $uri, $m):
         require __DIR__ . '/Controllers/InmuebleController.php';
-        (new \App\Controllers\InmuebleController())->inmueblesPorArrendador((int)$m[1]);
+        (new \App\Controllers\InmuebleController())->inmueblesPorArrendador($m[1]);
         exit;
         break;
 


### PR DESCRIPTION
## Summary
- read arrendador inmuebles from DynamoDB using the arrendador profile list with throttled batch reads and normalized output
- allow the inmueblesPorArrendador endpoint and router to accept numeric IDs or arr# keys while returning pk/sk rich payloads
- update the nueva póliza view to build the inmueble selector from Dynamo metadata and track pk/sk hints on the client

## Testing
- php -l Backend/admin/Models/InmueblesModel.php
- php -l Backend/admin/Models/AsesorModel.php
- php -l Backend/admin/Models/ArrendadorModel.php
- php -l Backend/admin/Controllers/InmuebleController.php
- php -l Backend/admin/router.php
- php -l Backend/admin/Views/polizas/nueva.php

------
https://chatgpt.com/codex/tasks/task_e_68ccf772e3b483239b5b01d17184fa28