### PR TITLE
Fix InvalidArgumentException namespace in InmuebleController

### DIFF
--- a/Backend/admin/Controllers/InmuebleController.php
+++ b/Backend/admin/Controllers/InmuebleController.php
@@ -87,7 +87,7 @@ class InmuebleController
 
         try {
             $inmueble = $this->model->obtenerPorId($pkDecodificado, $skDecodificado);
-        } catch (InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             $inmueble = null;
         }
 
@@ -212,7 +212,7 @@ class InmuebleController
 
         try {
             $inmueble = $this->model->obtenerPorId($pkDecodificado, $skDecodificado);
-        } catch (InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             $inmueble = null;
         }
 


### PR DESCRIPTION
## Summary
- ensure InvalidArgumentException references in InmuebleController use the global namespace when catching errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdab216af083238cc3188bcc508ea1