### PR TITLE
Refactor financiero module to rely solely on MySQL

### DIFF
--- a/Backend/admin/Controllers/FinancieroController.php
+++ b/Backend/admin/Controllers/FinancieroController.php
@@ -36,15 +36,14 @@ class FinancieroController
         }
 
         // Ej: compats legadas
-        $mesConsulta  = date('m Y', strtotime($mesSeleccionado)); // "07 2025"
         $anioConsulta = (int)date('Y', strtotime($mesSeleccionado));
         $mesNumerico  = (int)date('m', strtotime($mesSeleccionado));
 
         // --- Consultas al modelo ---
         $ingresosPorMesRaw   = $this->model->obtenerIngresosPorMes((string)$anioConsulta) ?? [];
-        $resumen             = $this->model->obtenerResumenMensual($mesConsulta) ?? ['total_mes' => 0, 'polizas_mes' => 0];
+        $resumen             = $this->model->obtenerResumenPorAnioMes($anioConsulta, $mesNumerico) ?? ['total_mes' => 0, 'polizas_mes' => 0];
         $ingresosAcumulados  = $this->model->obtenerIngresosAnuales((string)$anioConsulta) ?? 0.0;
-        $sumatorias          = $this->model->obtenerSumatoriasPorCanal($mesConsulta) ?? ['total_arrendamiento' => 0, 'total_inmobiliaria' => 0];
+        $sumatorias          = $this->model->obtenerSumatoriasPorCanalAnioMes($anioConsulta, $mesNumerico) ?? ['total_arrendamiento' => 0, 'total_inmobiliaria' => 0];
 
         // --- Variables planas para la vista ---
         $ingresosMes        = (float)($resumen['total_mes'] ?? 0);


### PR DESCRIPTION
## Summary
- drop Dynamo-based helper methods from the financiero model and rely on fecha_venta-backed queries
- update the financiero controller to use the new year/month aggregations from MySQL
- adjust annual totals to use fecha_venta as the single source of truth

## Testing
- php -l Backend/admin/Models/FinancieroModel.php
- php -l Backend/admin/Controllers/FinancieroController.php

------
https://chatgpt.com/codex/tasks/task_e_68ce541912f083239e3b3fa2e59f2edb