### PR TITLE
Refactor inquilino data access to MySQL

### DIFF
--- a/Backend/admin/Controllers/InquilinoController.php
+++ b/Backend/admin/Controllers/InquilinoController.php
@@ -565,7 +565,7 @@ class InquilinoController
     }
 
     /**
-     * Valida y sube un archivo a S3, registrándolo en Dynamo.
+     * Valida y sube un archivo a S3, registrándolo en MySQL.
      */
     private function manejarSubidaArchivo(
         int $idInquilino,


### PR DESCRIPTION
## Summary
- replace the DynamoDB-backed `InquilinoModel` with a PDO `Database` implementation that hydrates profile relations, manages archivos, and persists validation snapshots in MySQL
- update the inquilino controller documentation to reflect the new MySQL persistence layer

## Testing
- php -l Backend/admin/Models/InquilinoModel.php
- php -l Backend/admin/Controllers/InquilinoController.php

------
https://chatgpt.com/codex/tasks/task_e_68ce5bf3679883239370506faf8884e7