### PR TITLE
Validate media presign keys against MySQL

### DIFF
--- a/Backend/admin/Controllers/MediaController.php
+++ b/Backend/admin/Controllers/MediaController.php
@@ -4,11 +4,20 @@ declare(strict_types=1);
 namespace App\Controllers;
 
 require_once __DIR__ . '/../Helpers/S3Helper.php';
+require_once __DIR__ . '/../Models/MediaModel.php';
 
 use App\Helpers\S3Helper;
+use App\Models\MediaModel;
 
 class MediaController
 {
+    private MediaModel $mediaModel;
+
+    public function __construct()
+    {
+        $this->mediaModel = new MediaModel();
+    }
+
     /**
      * GET /media/presign?k=<base64url(s3_key)>&bucket=blog
      * Presigna un solo key.
@@ -29,8 +38,14 @@ class MediaController
 
         // TODO: autorizar que el usuario puede leer ese key
 
-        $s3   = new S3Helper($bkKey);
-        $url  = $s3->getPresignedUrl($key, '+10 minutes', [
+        if (!$this->mediaModel->keyExists($bkKey, $key)) {
+            http_response_code(404);
+            echo json_encode(['ok' => false, 'error' => 'Archivo no encontrado en MySQL']);
+            return;
+        }
+
+        $s3 = new S3Helper($bkKey);
+        $url = $s3->getPresignedUrl($key, '+10 minutes', [
             'ContentDisposition' => 'inline',
         ]);
 
@@ -62,16 +77,32 @@ class MediaController
             return;
         }
 
-        // TODO: autorizar lectura de estos keys
-        $s3   = new S3Helper($bk);
-        $out  = [];
-        foreach ($keys as $k) {
-            $k   = trim((string)$k);
-            if (!$k) continue;
-            $url = $s3->getPresignedUrl($k, '+10 minutes', ['ContentDisposition' => 'inline']);
-            if ($url) $out[] = ['key' => $k, 'url' => $url];
+        $validKeys = $this->mediaModel->filterValidKeys($keys, $bk);
+
+        if (empty($validKeys)) {
+            echo json_encode([
+                'ok'    => true,
+                'items' => [],
+                'omitidos' => array_values(array_unique(array_map('strval', $keys))),
+            ]);
+            return;
         }
 
-        echo json_encode(['ok' => true, 'items' => $out]);
+        $s3  = new S3Helper($bk);
+        $out = [];
+        foreach ($validKeys as $k) {
+            $url = $s3->getPresignedUrl($k, '+10 minutes', ['ContentDisposition' => 'inline']);
+            if ($url) {
+                $out[] = ['key' => $k, 'url' => $url];
+            }
+        }
+
+        $omitidos = array_values(array_diff(array_unique(array_map('strval', $keys)), $validKeys));
+
+        echo json_encode([
+            'ok'       => true,
+            'items'    => $out,
+            'omitidos' => $omitidos,
+        ]);
     }
 }

--- a/Backend/admin/Models/MediaModel.php
+++ b/Backend/admin/Models/MediaModel.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+require_once __DIR__ . '/../Core/Database.php';
+
+use App\Core\Database;
+use PDO;
+
+/**
+ * Modelo auxiliar para validar claves de archivos en buckets conocidos.
+ */
+class MediaModel extends Database
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Verifica si una clave existe para el bucket solicitado.
+     */
+    public function keyExists(string $bucket, string $key): bool
+    {
+        $key = trim($key);
+        if ($key === '') {
+            return false;
+        }
+
+        $query = $this->getBucketQuery($bucket, $key);
+        if (!$query) {
+            return false;
+        }
+
+        [$sql, $params] = $query;
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute($params);
+
+        return (bool)$stmt->fetchColumn();
+    }
+
+    /**
+     * Devuelve únicamente las claves válidas que existen en el bucket indicado.
+     * Mantiene el orden original recibido.
+     *
+     * @param array<int, string> $keys
+     * @return array<int, string>
+     */
+    public function filterValidKeys(array $keys, string $bucket): array
+    {
+        $cleanKeys = [];
+        foreach ($keys as $k) {
+            $k = trim((string) $k);
+            if ($k !== '') {
+                $cleanKeys[$k] = true; // usar arreglo asociativo para deduplicar
+            }
+        }
+
+        if (empty($cleanKeys)) {
+            return [];
+        }
+
+        $query = $this->getBucketQuery($bucket, array_keys($cleanKeys));
+        if (!$query) {
+            return [];
+        }
+
+        [$sql, $params] = $query;
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute($params);
+        $found = $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+
+        if (empty($found)) {
+            return [];
+        }
+
+        // Mantener el orden de entrada usando intersección manual.
+        $foundMap = array_flip($found);
+        $ordered = [];
+        foreach ($keys as $original) {
+            $original = trim((string) $original);
+            if ($original !== '' && isset($foundMap[$original])) {
+                $ordered[] = $original;
+            }
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * Construye la consulta SQL para el bucket solicitado.
+     *
+     * @param string $bucket
+     * @param string|array<int,string> $key
+     * @return array{0:string,1:array<string,mixed>}|null
+     */
+    private function getBucketQuery(string $bucket, $key): ?array
+    {
+        switch ($bucket) {
+            case 'inquilinos':
+                $column = 's3_key';
+                $table  = 'inquilinos_archivos';
+                break;
+            case 'arrendadores':
+                $column = 's3_key';
+                $table  = 'arrendadores_archivos';
+                break;
+            case 'blog':
+                $column = 'imagen_key';
+                $table  = 'blog_posts';
+                break;
+            default:
+                return null;
+        }
+
+        if (is_array($key)) {
+            $placeholders = [];
+            $params       = [];
+            foreach ($key as $idx => $value) {
+                $placeholder = ':k' . $idx;
+                $placeholders[]      = $placeholder;
+                $params[$placeholder] = $value;
+            }
+
+            if (empty($placeholders)) {
+                return null;
+            }
+
+            $sql = sprintf(
+                'SELECT DISTINCT %s FROM %s WHERE %s IN (%s)',
+                $column,
+                $table,
+                $column,
+                implode(', ', $placeholders)
+            );
+
+            return [$sql, $params];
+        }
+
+        $sql = sprintf(
+            'SELECT %s FROM %s WHERE %s = :key LIMIT 1',
+            $column,
+            $table,
+            $column
+        );
+
+        return [$sql, [':key' => $key]];
+    }
+}


### PR DESCRIPTION
## Summary
- instantiate a MediaModel inside MediaController to validate presign requests against MySQL tables
- add MediaModel helper to check key existence for inquilinos, arrendadores and blog buckets
- filter presign-many requests to only emit URLs for keys present in the database and report omitted keys

## Testing
- php -l Backend/admin/Controllers/MediaController.php
- php -l Backend/admin/Models/MediaModel.php

------
https://chatgpt.com/codex/tasks/task_e_68ce69d6a7608323bf060e688cc1617d