### PR TITLE
Refactor AWS y validación de identidad a fuentes MySQL

### DIFF
--- a/Backend/admin/Controllers/ValidacionAwsController.php
+++ b/Backend/admin/Controllers/ValidacionAwsController.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 namespace App\Controllers;
 
 require_once __DIR__ . '/../Core/Database.php';
+require_once __DIR__ . '/../Models/InquilinoModel.php';
 
 use App\Core\Database;
+use App\Models\InquilinoModel;
 use PDO;
 use Exception;
 
@@ -37,36 +39,27 @@ class ValidacionAwsController extends Database
         }
 
         try {
-            $this->db->beginTransaction();
-
-            // 1) Inquilino por slug
-            $stmt = $this->db->prepare("
-                SELECT id, slug, nombre_inquilino, apellidop_inquilino, apellidom_inquilino, tipo_id
-                FROM inquilinos
-                WHERE slug = ?
-                LIMIT 1
-            ");
-            $stmt->execute([$slug]);
-            $inquilino = $stmt->fetch(PDO::FETCH_ASSOC);
+            $inquilinoModel = new InquilinoModel();
+            $inquilino = $inquilinoModel->obtenerPorSlug($slug);
 
             if (!$inquilino) {
-                $this->db->rollBack();
                 http_response_code(404);
                 echo json_encode(['ok' => false, 'mensaje' => 'Inquilino no encontrado por slug.']);
                 return;
             }
 
-            $idInquilino = (int)$inquilino['id'];
+            $idInquilino = (int)($inquilino['id'] ?? 0);
+            if ($idInquilino <= 0) {
+                http_response_code(404);
+                echo json_encode(['ok' => false, 'mensaje' => 'Inquilino inválido.']);
+                return;
+            }
 
-            // 2) Archivos del inquilino
-            $stmt2 = $this->db->prepare("
-                SELECT id, tipo, s3_key, mime_type, created_at
-                FROM inquilinos_archivos
-                WHERE id_inquilino = ?
-                ORDER BY created_at ASC, id ASC
-            ");
-            $stmt2->execute([$idInquilino]);
-            $archivos = $stmt2->fetchAll(PDO::FETCH_ASSOC);
+            // 1) Archivos del inquilino desde el modelo (MySQL)
+            $archivos = $inquilino['archivos'] ?? [];
+            if ($archivos === []) {
+                $archivos = $inquilinoModel->obtenerArchivos($idInquilino);
+            }
 
             // Resumen rápido de lo que hay
             $flags = [
@@ -79,7 +72,8 @@ class ValidacionAwsController extends Database
             ];
 
             foreach ($archivos as $a) {
-                switch ($a['tipo']) {
+                $tipo = strtolower((string)($a['tipo'] ?? ''));
+                switch ($tipo) {
                     case 'selfie':               $flags['selfie'] = true; break;
                     case 'ine_frontal':          $flags['ine_frontal'] = true; break;
                     case 'ine_reverso':          $flags['ine_reverso'] = true; break;
@@ -88,11 +82,6 @@ class ValidacionAwsController extends Database
                     case 'comprobante_ingreso':  $flags['comprobantes']++; break;
                 }
             }
-
-            // 3) Aseguramos registro en validaciones (si no existe, insert con defaults)
-            $stmt3 = $this->db->prepare("SELECT id FROM inquilinos_validaciones WHERE id_inquilino = ? LIMIT 1");
-            $stmt3->execute([$idInquilino]);
-            $valRow = $stmt3->fetch(PDO::FETCH_ASSOC);
 
             $comentario = sprintf(
                 "[%s] Validación iniciada manualmente (mock). Archivos: selfie=%s, INE(F)=%s, INE(R)=%s, pasaporte=%s, FM=%s, comprobantes=%d",
@@ -105,23 +94,36 @@ class ValidacionAwsController extends Database
                 $flags['comprobantes']
             );
 
+            // 2) Bitácora y registro en MySQL
+            $this->db->beginTransaction();
+
+            $stmt3 = $this->db->prepare('SELECT id FROM inquilinos_validaciones WHERE id_inquilino = :id LIMIT 1');
+            $stmt3->execute([':id' => $idInquilino]);
+            $valRow = $stmt3->fetch(PDO::FETCH_ASSOC);
+
             if ($valRow && isset($valRow['id'])) {
-                $stmt4 = $this->db->prepare("
+                $sqlUpdate = <<<'SQL'
                     UPDATE inquilinos_validaciones
-                    SET comentarios = CONCAT(COALESCE(comentarios,''), '\n', :comentario)
+                    SET comentarios = CASE
+                        WHEN COALESCE(TRIM(comentarios), '') = '' THEN :comentario
+                        ELSE CONCAT(comentarios, '\n', :comentario)
+                    END,
+                        updated_at = NOW()
                     WHERE id_inquilino = :id
-                ");
+                SQL;
+                $stmt4 = $this->db->prepare($sqlUpdate);
                 $stmt4->execute([
                     ':comentario' => $comentario,
                     ':id' => $idInquilino
                 ]);
             } else {
-                $stmt4 = $this->db->prepare("
+                $sqlInsert = <<<'SQL'
                     INSERT INTO inquilinos_validaciones
                         (id_inquilino, comentarios)
                     VALUES
                         (:id, :comentario)
-                ");
+                SQL;
+                $stmt4 = $this->db->prepare($sqlInsert);
                 $stmt4->execute([
                     ':id' => $idInquilino,
                     ':comentario' => $comentario
@@ -129,6 +131,15 @@ class ValidacionAwsController extends Database
             }
 
             $this->db->commit();
+
+            // 3) Snapshot en columnas de validación (MySQL)
+            $payload = [
+                'evento'    => 'validacion_iniciada',
+                'comentario'=> $comentario,
+                'archivos'  => $flags,
+                'timestamp' => date(DATE_ATOM),
+            ];
+            $validacionGuardada = $inquilinoModel->guardarValidacionIdentidad($idInquilino, $payload, $comentario, 2);
 
             // 4) Respuesta (aún sin AWS, solo handshake)
             echo json_encode([
@@ -139,7 +150,8 @@ class ValidacionAwsController extends Database
                     'nombre' => trim($inquilino['nombre_inquilino'] . ' ' . $inquilino['apellidop_inquilino'] . ' ' . ($inquilino['apellidom_inquilino'] ?? '')),
                     'tipo_id' => $inquilino['tipo_id'],
                     'archivos' => $flags
-                ]
+                ],
+                'validacion_actualizada' => $validacionGuardada
             ]);
         } catch (Exception $e) {
             if ($this->db->inTransaction()) {


### PR DESCRIPTION
## Summary
- Reescritura de ValidacionAwsController para obtener inquilinos y archivos mediante InquilinoModel y registrar comentarios/payloads directamente en MySQL.
- Normalización de la respuesta de validación AWS guardando un snapshot en columnas de validación de MySQL.
- Ajustes en ValidacionIdentidadController::resultado para hidratar archivos desde MySQL y exponer validaciones normalizadas al frontend.

## Testing
- php -l Backend/admin/Controllers/ValidacionAwsController.php
- php -l Backend/admin/Controllers/ValidacionIdentidadController.php

------
https://chatgpt.com/codex/tasks/task_e_68ce6b9a5da4832398082e16871d2edc