### PR TITLE
Fix IA view URLs to use admin base paths

### DIFF
--- a/Backend/admin/Views/ia/index.php
+++ b/Backend/admin/Views/ia/index.php
@@ -1,3 +1,9 @@
+<?php
+require_once __DIR__ . '/../../Helpers/url.php';
+
+$iaHistorialUrl = admin_url('/ia/historial');
+$iaChatUrl      = admin_url('/ia/chat');
+?>
 <!-- Chat Card -->
 <div
     class="mx-auto w-full max-w-6xl sm:mt-6 flex flex-col
@@ -16,7 +22,7 @@
         <div class="flex-1">
             <h1 class="text-sm font-semibold text-indigo-300"><?= htmlspecialchars($headerTitle) ?></h1>
         </div>
-        <a href="ia/historial" class="text-xs text-indigo-400 hover:underline">Historial</a>
+        <a href="<?= htmlspecialchars($iaHistorialUrl, ENT_QUOTES, 'UTF-8') ?>" class="text-xs text-indigo-400 hover:underline">Historial</a>
     </div>
 
     <!-- Chat area -->
@@ -136,7 +142,11 @@
 
             try {
                 // RUTA RELATIVA: respeta tu $base del router
-                const res = await fetch("ia/chat", {
+                const chatEndpoint = (typeof window.joinAdmin === 'function')
+                    ? window.joinAdmin('/ia/chat')
+                    : <?= json_encode($iaChatUrl, JSON_UNESCAPED_SLASHES) ?>;
+
+                const res = await fetch(chatEndpoint, {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json"


### PR DESCRIPTION
## Summary
- ensure the IA view loads URL helper functions and computes admin-aware URLs for historial and chat endpoints
- update the historial link and chat fetch call to use the resolved admin base path so requests work regardless of installation path

## Testing
- php -l Backend/admin/Views/ia/index.php

------
https://chatgpt.com/codex/tasks/task_e_68ce70e73a388323ad822af5767024f7