### PR TITLE
Refactor admin base URL handling

### DIFF
--- a/Backend/admin/Helpers/SessionHelper.php
+++ b/Backend/admin/Helpers/SessionHelper.php
@@ -1,24 +1,26 @@
 <?php
+
 namespace App\Helpers;
 
 class SessionHelper
 {
     public static function startAndVerifyTimeout($timeoutSeconds = 60)
     {
-        $baseUrl = '/as-2026/Backend/admin' ?? '/';
+        require_once __DIR__ . '/../config/config.php';
+
         if (session_status() === PHP_SESSION_NONE) {
             session_start();
         }
         // Verifica si el usuario está logueado
         if (!isset($_SESSION['user'])) {
-            header("Location: $baseUrl/login");
+            header('Location: ' . \admin_base_url('login'));
             exit;
         }
         // Verifica tiempo de inactividad
         if (isset($_SESSION['last_activity']) && (time() - $_SESSION['last_activity']) > $timeoutSeconds) {
             session_unset();
             session_destroy();
-            header("Location: $baseUrl/login?expired=true");
+            header('Location: ' . \admin_base_url('login?expired=true'));
             exit;
         }
 

--- a/Backend/admin/Middleware/AuthMiddleware.php
+++ b/Backend/admin/Middleware/AuthMiddleware.php
@@ -6,15 +6,15 @@ class AuthMiddleware
 {
     public static function verificarSesion($timeoutSeconds = 1800)
     {
+        require_once __DIR__ . '/../config/config.php';
+
         if (session_status() === PHP_SESSION_NONE) {
             session_start();
         }
 
-        $baseUrl = '/as-2026/Backend/admin' ?? '/';
-
         // Si no hay usuario logueado
         if (empty($_SESSION['user'])) {
-            header("Location: $baseUrl/login");
+            header('Location: ' . \admin_base_url('login'));
             exit;
         }
 
@@ -22,7 +22,7 @@ class AuthMiddleware
         if (isset($_SESSION['last_activity']) && (time() - $_SESSION['last_activity']) > $timeoutSeconds) {
             session_unset();
             session_destroy();
-            header("Location: /login?expired=true");
+            header('Location: ' . \admin_base_url('login?expired=true'));
             exit;
         }
 

--- a/Backend/admin/config/config.php
+++ b/Backend/admin/config/config.php
@@ -5,6 +5,37 @@ $appUrl = $credentials['app']['url'] ?? 'https://crm.arrendamientoseguro.app';
 
 define('APP_URL', $appUrl);
 
+if (!function_exists('admin_base_url')) {
+    function admin_base_url(string $path = ''): string
+    {
+        static $baseUrl;
+
+        if ($baseUrl === null) {
+            $envBaseUrl = getenv('ADMIN_BASE_URL');
+
+            if ($envBaseUrl !== false) {
+                $envBaseUrl = trim($envBaseUrl);
+            }
+
+            if (!empty($envBaseUrl)) {
+                $baseUrl = $envBaseUrl;
+            } elseif (defined('APP_URL') && APP_URL !== '') {
+                $baseUrl = APP_URL;
+            } else {
+                $baseUrl = '/as-2026/Backend/admin';
+            }
+        }
+
+        $normalizedBase = rtrim($baseUrl, '/');
+
+        if ($path === '') {
+            return $normalizedBase;
+        }
+
+        return $normalizedBase . '/' . ltrim($path, '/');
+    }
+}
+
 $aws = $credentials['aws'] ?? [];
 $ses = $aws['ses'] ?? [];
 

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -5,19 +5,20 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 session_start();
+require_once __DIR__ . '/config/config.php';
 require_once __DIR__ . '/Helpers/url.php';
 require_once __DIR__ . '/aws-sdk-php/aws-autoloader.php';
 
 $uri  = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-$base = '/as-2026/Backend/admin';
-// $base = 'https://crm.arrendamientoseguro.app'; // Cambia aquí si tu base cambia en prod/dev
+$base = admin_base_url();
+// $uri  = str_replace($base, '', $uri);
 $uri  = str_replace($base, '', $uri);
 $uri  = rtrim($uri, '/'); // Evita problemas con barras al final
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 // Rutas públicas (NO requieren sesión)
 
 // Ajusta solo esta constante si cambia el prefijo
-$ADMIN_BASE = '/as-2026/Backend/admin';
+$ADMIN_BASE = admin_base_url();
 
 // Flags
 $isAdmin    = str_starts_with($uri, $ADMIN_BASE);
@@ -27,14 +28,14 @@ $isCallback = ($uri === "$ADMIN_BASE/validaciones/demandas/callback");
 // Si estoy en el área admin y NO es /login ni el callback,
 // y no hay sesión → redirige a /login (una sola vez).
 if ($isAdmin && !$isLogin && !$isCallback && empty($_SESSION['user_id'])) {
-    header("Location: $ADMIN_BASE/login", true, 302);
+    header('Location: ' . admin_base_url('login'), true, 302);
     exit;
 }
 
 // Redirección a login si no está autenticado
 $publicRoutes = ['/login'];
 if (!isset($_SESSION['user']) && !in_array($uri, $publicRoutes)) {
-    header('Location: ' . $base . '/login');
+    header('Location: ' . admin_base_url('login'));
     exit;
 }
 


### PR DESCRIPTION
## Summary
- add an `admin_base_url()` helper derived from APP_URL with optional ADMIN_BASE_URL override
- update the router and middleware helpers to reuse the new helper instead of hard-coded admin paths

## Testing
- php -l Backend/admin/config/config.php
- php -l Backend/admin/router.php
- php -l Backend/admin/Middleware/AuthMiddleware.php
- php -l Backend/admin/Helpers/SessionHelper.php

------
https://chatgpt.com/codex/tasks/task_e_68ceeabd5c408323a339cca8326a8aca