### PR TITLE
Refactor admin routes to use centralized helpers

### DIFF
--- a/Backend/admin/Views/404.php
+++ b/Backend/admin/Views/404.php
@@ -32,7 +32,7 @@
     La página que buscas no existe, fue movida o nunca estuvo aquí.<br>
     Regresa al panel y sigue explorando.
   </p>
-  <a href="/as-2026/Backend/admin/dashboard"
+  <a href="<?= admin_url('dashboard') ?>"
     class="inline-block px-8 py-3 rounded-2xl bg-[var(--rosa-fuerte)] text-white font-semibold shadow-xl hover:bg-[var(--rosa-acento)] hover:text-[var(--texto-oscuro)] focus:outline-none focus:ring-2 focus:ring-[var(--rosa-fuerte)] focus:ring-offset-2
     transition-all duration-200 animate-bounce">
     Volver al Dashboard

--- a/Backend/admin/Views/blog/create.php
+++ b/Backend/admin/Views/blog/create.php
@@ -3,7 +3,7 @@
   <h1 class="text-3xl font-bold text-indigo-200 mb-3">Nueva Entrada de Blog</h1>
   <p class="mb-7 text-indigo-400">Publica artículos con imágenes, categorías y contenido enriquecido. Optimiza para SEO.</p>
 
-  <form method="POST" action="<?= $baseUrl ?>/blog/store" enctype="multipart/form-data" class="bg-white/10 backdrop-blur-lg rounded-2xl shadow-2xl p-8 border border-indigo-900/20 space-y-7" id="blogForm">
+  <form method="POST" action="<?= admin_url('blog/store') ?>" enctype="multipart/form-data" class="bg-white/10 backdrop-blur-lg rounded-2xl shadow-2xl p-8 border border-indigo-900/20 space-y-7" id="blogForm">
 
     <!-- Título -->
     <div>
@@ -68,4 +68,4 @@
 </div>
 <!-- TinyMCE CDN con tu API Key -->
 <script src="https://cdn.tiny.cloud/1/g62vvex6kxlmgwndrpkcix8mabqfyep57qhfn3jwnwxg1iuf/tinymce/7/tinymce.min.js" referrerpolicy="origin"></script>
-<script src="<?= $baseUrl ?>/assets/blog.js"></script>
+<script src="<?= asset_url('blog.js') ?>"></script>

--- a/Backend/admin/Views/blog/edit.php
+++ b/Backend/admin/Views/blog/edit.php
@@ -1,5 +1,5 @@
 <!-- admin/Views/blog/edit.php -->
- <?php
+<?php
 require_once __DIR__ . '/../../Helpers/S3Helper.php';
 use App\Helpers\S3Helper;
 $s3 = new S3Helper('blog');
@@ -9,7 +9,8 @@ $s3 = new S3Helper('blog');
   <h1 class="text-3xl font-bold text-indigo-200 mb-3">Editar Entrada de Blog</h1>
   <p class="mb-7 text-indigo-400">Modifica el contenido, imagen o etiquetas SEO de este artículo.</p>
 
-  <form method="POST" action="/as-2026/Backend/admin/blog/update?id=<?= $post['id'] ?>" enctype="multipart/form-data"
+  <?php $postId = (string)($post['id'] ?? ''); ?>
+  <form method="POST" action="<?= admin_url('blog/update') . '?id=' . urlencode($postId) ?>" enctype="multipart/form-data"
     class="bg-white/10 backdrop-blur-lg rounded-2xl shadow-2xl p-8 border border-indigo-900/20 space-y-7">
 
     <!-- Título -->
@@ -81,7 +82,7 @@ $s3 = new S3Helper('blog');
     </div>
 
     <div class="flex justify-between gap-4">
-      <a href="/as-2026/Backend/admin/blog" class="inline-block px-6 py-3 rounded-xl bg-indigo-800 hover:bg-indigo-700 text-white font-bold shadow transition text-base">Cancelar</a>
+      <a href="<?= admin_url('blog') ?>" class="inline-block px-6 py-3 rounded-xl bg-indigo-800 hover:bg-indigo-700 text-white font-bold shadow transition text-base">Cancelar</a>
       <button type="submit"
         class="px-8 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-bold shadow-lg transition text-base">
         Guardar cambios

--- a/Backend/admin/Views/blog/index.php
+++ b/Backend/admin/Views/blog/index.php
@@ -6,7 +6,7 @@ $s3 = new S3Helper('blog');
 
 <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold">Entradas del Blog</h1>
-    <a href="/as-2026/Backend/admin/blog/create"
+    <a href="<?= admin_url('blog/create') ?>"
        class="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded shadow">
         + Nueva Entrada
     </a>
@@ -42,7 +42,8 @@ $s3 = new S3Helper('blog');
                     ?>
                 </div>
                 <div class="mt-auto flex gap-2">
-                    <a href="/as-2026/Backend/admin/blog/edit?id=<?= $post['id'] ?>"
+                    <?php $postId = (string)($post['id'] ?? ''); ?>
+                    <a href="<?= admin_url('blog/edit') . '?id=' . urlencode($postId) ?>"
                        class="flex-1 text-center py-1.5 bg-indigo-600 hover:bg-indigo-700 rounded text-white text-sm transition">Editar</a>
                     <!-- Si quieres eliminar, añade aquí -->
                     <!--

--- a/Backend/admin/Views/inquilino/validacion_identidad.php
+++ b/Backend/admin/Views/inquilino/validacion_identidad.php
@@ -1,5 +1,18 @@
+<?php
+$adminIdentityBase = '/';
+if (function_exists('admin_url')) {
+    $adminIdentityBase = admin_url();
+} elseif (function_exists('admin_base_url')) {
+    $adminIdentityBase = admin_base_url();
+}
+
+$adminIdentityBase = rtrim((string) $adminIdentityBase, '/');
+if ($adminIdentityBase === '') {
+    $adminIdentityBase = '/';
+}
+?>
 <section class="relative min-h-screen flex items-center justify-center bg-white/5 backdrop-blur-md border border-white/20 rounded-2xl shadow-[0_8px_32px_0_rgba(31,38,135,0.37)] py-8 md:py-16 px-2">
-    <input type="hidden" id="baseUrl" value="<?= $baseUrl ?>">
+    <input type="hidden" id="baseUrl" value="<?= htmlspecialchars($adminIdentityBase, ENT_QUOTES, 'UTF-8') ?>">
   <!-- Fondo visual animado -->
   <div class="absolute inset-0 -z-10">
     <div class="absolute left-0 top-1/2 -translate-y-1/2 w-48 h-48 bg-indigo-900/30 blur-3xl rounded-full"></div>
@@ -149,4 +162,4 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
-<script src="<?= $baseUrl ?>/assets/validacionIdentidad.js"></script>
+<script src="<?= asset_url('validacionIdentidad.js') ?>"></script>

--- a/Backend/admin/Views/inquilino/validaciones.php
+++ b/Backend/admin/Views/inquilino/validaciones.php
@@ -11,9 +11,27 @@ $nombreCompleto = trim(
 $nombre = $h($nombreCompleto ?: 'Nombre Apellido');
 $slug    = $h($inquilino['slug'] ?? 'slug-ejemplo');
 $idInq   = (int)($inquilino['id'] ?? 0);
-$ADMIN_BASE = $admin_base_url ?? '/as-2026/Backend/admin';
+$helperBaseUrl = null;
+if (function_exists('admin_base_url')) {
+    $helperBaseUrl = admin_base_url();
+} elseif (function_exists('admin_url')) {
+    $helperBaseUrl = admin_url();
+}
+
+if (!is_string($helperBaseUrl) || trim($helperBaseUrl) === '') {
+    $helperBaseUrl = '/';
+}
+
+$ADMIN_BASE = $admin_base_url ?? $helperBaseUrl;
 if (!is_string($ADMIN_BASE) || trim($ADMIN_BASE) === '') {
-    $ADMIN_BASE = '/as-2026/Backend/admin';
+    $ADMIN_BASE = $helperBaseUrl;
+}
+
+$ADMIN_BASE = rtrim($ADMIN_BASE, '/');
+$resolvedBaseUrl = $baseUrl ?? $helperBaseUrl;
+$resolvedBaseUrl = rtrim((string) $resolvedBaseUrl, '/');
+if ($resolvedBaseUrl === '') {
+    $resolvedBaseUrl = '/';
 }
 $idInquilino = (int)($inquilino['id'] ?? $idInquilino ?? 0);
 $apP         = $inquilino['apellidop_inquilino'] ?? '';
@@ -773,8 +791,8 @@ function chipColor($valor)
     </div>
     <script>
         // Contexto global de validaciones
-        window.baseUrl = <?= json_encode($baseUrl ?? '/as-2026/Backend/admin') ?>;
-        window.ADMIN_BASE = <?= json_encode($ADMIN_BASE ?? '/as-2026/Backend/admin') ?>;
+        window.baseUrl = <?= json_encode($resolvedBaseUrl) ?>;
+        window.ADMIN_BASE = <?= json_encode($ADMIN_BASE) ?>;
 
         // 👇 aseguramos que siempre se definan correctamente
         window.ID_INQ = <?= (int)($inquilino['id'] ?? 0) ?>;
@@ -789,14 +807,14 @@ function chipColor($valor)
         };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
-    <script src="<?= $baseUrl ?>/assets/validaciones-core.js"></script>
-    <script src="<?= $baseUrl ?>/assets/validaciones-archivos.js"></script>
-    <script src="<?= $baseUrl ?>/assets/validaciones-rostro.js"></script>
-    <script src="<?= $baseUrl ?>/assets/validaciones-identidad.js"></script>
-    <script src="<?= $baseUrl ?>/assets/validaciones-pago.js"></script>
-    <script src="<?= $baseUrl ?>/assets/validaciones-modal.js"></script>
-    <script src="<?= $baseUrl ?>/assets/validaciones-botones.js"></script>
-    <script src="<?= $baseUrl ?>/assets/validaciones-demandas.js"></script>
+    <script src="<?= asset_url('validaciones-core.js') ?>"></script>
+    <script src="<?= asset_url('validaciones-archivos.js') ?>"></script>
+    <script src="<?= asset_url('validaciones-rostro.js') ?>"></script>
+    <script src="<?= asset_url('validaciones-identidad.js') ?>"></script>
+    <script src="<?= asset_url('validaciones-pago.js') ?>"></script>
+    <script src="<?= asset_url('validaciones-modal.js') ?>"></script>
+    <script src="<?= asset_url('validaciones-botones.js') ?>"></script>
+    <script src="<?= asset_url('validaciones-demandas.js') ?>"></script>
     <script>
         (function() {
             const modal = document.getElementById('archivo-preview-modal');

--- a/Backend/admin/assets/blog.js
+++ b/Backend/admin/assets/blog.js
@@ -1,3 +1,18 @@
+const ADMIN_BASE = (window.ADMIN_BASE || window.baseurl || '').replace(/\/$/, '');
+const joinAdminUrl = (path = '') => {
+        const normalizedPath = path
+                ? path.startsWith('/')
+                        ? path
+                        : `/${path}`
+                : '';
+
+        if (!ADMIN_BASE) {
+                return normalizedPath || '/';
+        }
+
+        return `${ADMIN_BASE}${normalizedPath}`;
+};
+
 // Drag & drop image preview
 const dropzone = document.getElementById("dropzone");
 const fileInput = document.getElementById("image");
@@ -124,7 +139,7 @@ document.addEventListener("DOMContentLoaded", function () {
 						"Entrada de blog creada correctamente.",
 					confirmButtonText: "Ir al blog",
 				}).then(() => {
-					window.location.href = "/as-2026/Backend/admin/blog";
+                                        window.location.href = joinAdminUrl('blog');
 				});
 			} else {
 				Swal.fire({

--- a/Backend/admin/assets/validacionIdentidad.js
+++ b/Backend/admin/assets/validacionIdentidad.js
@@ -11,7 +11,22 @@ const ineReverso = document.getElementById("ineReverso");
 const selfie = document.getElementById("selfie");
 const btnValidar = document.getElementById("btn-validar-identidad");
 const resultados = document.getElementById("resultadosValidacion");
-const baseUrl = document.getElementById("baseUrl").value;
+const baseUrlInput = document.getElementById("baseUrl");
+const baseUrl = baseUrlInput ? baseUrlInput.value : '';
+const identityAdminBase = (window.ADMIN_BASE || window.baseUrl || baseUrl || '').replace(/\/$/, '');
+const joinIdentityAdminUrl = (path = '') => {
+        const normalizedPath = path
+                ? path.startsWith('/')
+                        ? path
+                        : `/${path}`
+                : '';
+
+        if (!identityAdminBase) {
+                return normalizedPath || '/';
+        }
+
+        return `${identityAdminBase}${normalizedPath}`;
+};
 
 // --- Modal de imagen fullscreen ---
 window.abrirModalImagen = function (src, titulo) {
@@ -88,10 +103,9 @@ function archivoPresenteOImagenDemo(input, previewId) {
 	const imagenCargada = preview?.src?.length > 0;
 	return !!fileCargado || imagenCargada;
 }
-const BASE_URL = "http://localhost/as-2026/Backend/admin" ?? "/";
 // --- Simula validación con archivo local json.json ---
 async function validarSimulado() {
-	const response = await fetch(`${BASE_URL}/assets/json.json`);
+        const response = await fetch(joinIdentityAdminUrl('assets/json.json'));
 
 	if (!response.ok) throw new Error("No se pudo cargar json.json");
 	const json = await response.json();


### PR DESCRIPTION
## Summary
- replace hard-coded admin links in blog and error views with the admin_url helper
- normalize base URL handling in inquilino validation views and load assets via asset_url
- update blog.js and validacionIdentidad.js to build routes from window.ADMIN_BASE instead of fixed strings

## Testing
- php -l Backend/admin/Views/blog/index.php
- php -l Backend/admin/Views/404.php
- php -l Backend/admin/Views/blog/edit.php
- php -l Backend/admin/Views/blog/create.php
- php -l Backend/admin/Views/inquilino/validaciones.php
- php -l Backend/admin/Views/inquilino/validacion_identidad.php

------
https://chatgpt.com/codex/tasks/task_e_68ceec35c27c832382217133dc35e64b