### PR TITLE
Adjust admin base URL handling for local development

### DIFF
--- a/Backend/admin/config/credentials.php
+++ b/Backend/admin/config/credentials.php
@@ -11,7 +11,7 @@ if (file_exists($localFile)) {
 
 return [
     'app' => [
-        'url' => getenv('APP_URL') ?: 'https://crm.arrendamientoseguro.app',
+        'url' => getenv('APP_URL') ?: null,
     ],
     'database' => [
         'host'     => getenv('DB_HOST') ?: 'localhost',


### PR DESCRIPTION
## Summary
- default the app URL credential to an empty value instead of the production domain
- compute the admin base URL dynamically when APP_URL is missing or points to another host

## Testing
- php -l Backend/admin/config/credentials.php
- php -l Backend/admin/config/config.php
- php -r "\$_SERVER['HTTP_HOST']='localhost'; \$_SERVER['SCRIPT_NAME']='/as-2026/Backend/admin/login.php'; require 'Backend/admin/config/config.php'; echo admin_base_url();"

------
https://chatgpt.com/codex/tasks/task_e_68cf11ebe4a88323a1635a7459a25f05