### PR TITLE
Normaliza cálculo de días restantes en dashboard

### DIFF
--- a/Backend/admin/Views/dashboard/index.php
+++ b/Backend/admin/Views/dashboard/index.php
@@ -266,13 +266,19 @@ use App\Helpers\TextHelper;
 
                     if ($fechaVencimiento instanceof DateTimeInterface) {
                         $fechaFormateada = TextHelper::titleCase($fechaVencimiento->format('d/m/Y'));
-                        $hoy = new DateTime();
-                        $diasRestantes = $hoy->diff($fechaVencimiento)->days;
-                        if ($fechaVencimiento < $hoy) {
-                            $dias = '-' . $diasRestantes;
-                        } else {
-                            $dias = (string)$diasRestantes;
+                        $venceNormalizado = $fechaVencimiento instanceof \DateTimeImmutable
+                            ? $fechaVencimiento->setTime(0, 0)
+                            : \DateTimeImmutable::createFromMutable($fechaVencimiento)->setTime(0, 0);
+
+                        $hoy = new \DateTimeImmutable('today');
+                        $intervalo = $hoy->diff($venceNormalizado);
+                        $diasRestantes = (int)$intervalo->format('%r%a');
+
+                        if ($intervalo->invert === 0 && $diasRestantes > 0) {
+                            $diasRestantes += 1;
                         }
+
+                        $dias = (string)$diasRestantes;
                     } else {
                         $fechaFormateada = '—';
                         $dias = '—';


### PR DESCRIPTION
## Summary
- normaliza las fechas de hoy y vencimiento a medianoche antes de calcular los días restantes
- ajusta el cálculo para conservar el signo y sumar un día cuando el vencimiento aún es futuro

## Testing
- php -l Backend/admin/Views/dashboard/index.php
- php -r '$hoy = new \DateTimeImmutable("2024-09-20"); $vence = new \DateTimeImmutable("2024-10-01"); $venceNormalizado = $vence->setTime(0,0); $intervalo = $hoy->diff($venceNormalizado); $diasRestantes = (int)$intervalo->format("%r%a"); if ($intervalo->invert === 0 && $diasRestantes > 0) { $diasRestantes += 1; } echo $diasRestantes, "\n";'


------
https://chatgpt.com/codex/tasks/task_e_68cf48e9c73c832381bc72d62f02448b