### PR TITLE
Normaliza búsqueda de pólizas sin tildes

### DIFF
--- a/Backend/admin/Helpers/NormalizadoHelper.php
+++ b/Backend/admin/Helpers/NormalizadoHelper.php
@@ -89,6 +89,38 @@ class NormalizadoHelper
     }
 
     /**
+     * Elimina tildes/diacríticos conservando el texto base.
+     */
+    public static function sinDiacriticos(?string $val): string
+    {
+        if ($val === null || $val === '') {
+            return '';
+        }
+
+        $normalizado = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $val);
+
+        if ($normalizado === false) {
+            return (string) $val;
+        }
+
+        return $normalizado;
+    }
+
+    /**
+     * Normaliza texto para búsquedas en minúsculas sin diacríticos.
+     */
+    public static function normalizarBusqueda(?string $val): string
+    {
+        $val = self::lower($val);
+
+        if ($val === '') {
+            return '';
+        }
+
+        return self::sinDiacriticos($val);
+    }
+
+    /**
      * Normaliza texto a slug (ej. para URLs).
      */
     public static function slug(?string $val): string

--- a/Backend/admin/Models/PolizaModel.php
+++ b/Backend/admin/Models/PolizaModel.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 require_once __DIR__ . '/../Core/Database.php';
 
+use App\Helpers\NormalizadoHelper;
 use App\Core\Database;
 use PDO;
 
@@ -174,7 +175,7 @@ class PolizaModel extends Database
             return $polizas;
         }
 
-        $needle    = mb_strtolower($termino, 'UTF-8');
+        $needle    = NormalizadoHelper::normalizarBusqueda($termino);
         $esNumero  = ctype_digit($termino);
 
         return array_values(array_filter($polizas, static function (array $poliza) use ($needle, $esNumero, $termino): bool {
@@ -192,7 +193,7 @@ class PolizaModel extends Database
             ];
 
             foreach ($campos as $campo) {
-                $valor = mb_strtolower((string)($poliza[$campo] ?? ''), 'UTF-8');
+                $valor = NormalizadoHelper::normalizarBusqueda((string)($poliza[$campo] ?? ''));
                 if ($valor !== '' && mb_strpos($valor, $needle) !== false) {
                     return true;
                 }


### PR DESCRIPTION
## Summary
- añade utilidades en `NormalizadoHelper` para quitar diacríticos y normalizar texto de búsqueda
- aplica la normalización sin tildes en `PolizaModel::filtrarPolizasPorBusqueda` para búsquedas consistentes

## Testing
- php -l Backend/admin/Helpers/NormalizadoHelper.php
- php -l Backend/admin/Models/PolizaModel.php

------
https://chatgpt.com/codex/tasks/task_e_68cf5121472c832385dc4fe9a41897ce