### PR TITLE
Normaliza filtros de búsqueda de pólizas

### DIFF
--- a/Backend/admin/Models/PolizaModel.php
+++ b/Backend/admin/Models/PolizaModel.php
@@ -465,13 +465,19 @@ class PolizaModel extends Database
         $buscarTerm = null;
         if ($buscar !== null && trim($buscar) !== '') {
             $buscarTerm = trim($buscar);
-            $like = "%{$buscarTerm}%";
+            $buscarNormalizado = NormalizadoHelper::sinDiacriticos($buscarTerm);
+            $like = "%{$buscarNormalizado}%";
+
+            $collate = static fn (string $campo): string => sprintf(
+                'CONVERT(%s USING utf8mb4) COLLATE utf8mb4_unicode_ci',
+                $campo
+            );
 
             $sub = [
-                'i.nombre_inquilino LIKE :t1',
-                'i.apellidop_inquilino LIKE :t2',
-                'i.apellidom_inquilino LIKE :t3',
-                'arr.nombre_arrendador LIKE :t4',
+                $collate('i.nombre_inquilino') . ' LIKE :t1',
+                $collate('i.apellidop_inquilino') . ' LIKE :t2',
+                $collate('i.apellidom_inquilino') . ' LIKE :t3',
+                $collate('arr.nombre_arrendador') . ' LIKE :t4',
             ];
             $params[':t1'] = $like;
             $params[':t2'] = $like;
@@ -527,13 +533,19 @@ class PolizaModel extends Database
         $buscarTerm = null;
         if ($buscar !== null && trim($buscar) !== '') {
             $buscarTerm = trim($buscar);
-            $like = "%{$buscarTerm}%";
+            $buscarNormalizado = NormalizadoHelper::sinDiacriticos($buscarTerm);
+            $like = "%{$buscarNormalizado}%";
+
+            $collate = static fn (string $campo): string => sprintf(
+                'CONVERT(%s USING utf8mb4) COLLATE utf8mb4_unicode_ci',
+                $campo
+            );
 
             $sub = [
-                'i.nombre_inquilino LIKE :t1',
-                'i.apellidop_inquilino LIKE :t2',
-                'i.apellidom_inquilino LIKE :t3',
-                'arr.nombre_arrendador LIKE :t4',
+                $collate('i.nombre_inquilino') . ' LIKE :t1',
+                $collate('i.apellidop_inquilino') . ' LIKE :t2',
+                $collate('i.apellidom_inquilino') . ' LIKE :t3',
+                $collate('arr.nombre_arrendador') . ' LIKE :t4',
             ];
             $params[':t1'] = $like;
             $params[':t2'] = $like;


### PR DESCRIPTION
## Summary
- normaliza el término de búsqueda con NormalizadoHelper::sinDiacriticos en los filtros SQL de pólizas
- aplica comparación con collation insensible a acentos para nombres de inquilinos y arrendadores tanto en paginado como en conteos

## Testing
- php -l Backend/admin/Models/PolizaModel.php

------
https://chatgpt.com/codex/tasks/task_e_68cf537fa9b08323990e3f41527e45dc