### PR TITLE
Add opt-out flag for global loader

### DIFF
--- a/Backend/admin/Views/ia/index.php
+++ b/Backend/admin/Views/ia/index.php
@@ -147,6 +147,7 @@ $iaChatUrl      = admin_url('/ia/chat');
                     : <?= json_encode($iaChatUrl, JSON_UNESCAPED_SLASHES) ?>;
 
                 const res = await fetch(chatEndpoint, {
+                    skipLoader: true,
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json"

--- a/Backend/admin/assets/main.js
+++ b/Backend/admin/assets/main.js
@@ -132,24 +132,38 @@ document.addEventListener("DOMContentLoaded", function () {
 	const _fetch = window.fetch;
 
 	// Sobreescribimos fetch para mostrar/ocultar loader automáticamente
-	window.fetch = async function (resource, options) {
-		try {
-			// Mostrar loader al iniciar cualquier petición
-			showLoader("Procesando información...");
+        window.fetch = async function (resource, options) {
+                const shouldSkipLoader = options?.skipLoader === true;
+                let fetchOptions = options;
 
-			// Ejecutar la petición real
-			const response = await _fetch(resource, options);
+                if (options && typeof options === "object" && "skipLoader" in options) {
+                        const { skipLoader, ...rest } = options;
+                        fetchOptions = rest;
+                }
 
-			// Ocultar loader al terminar
-			hideLoader();
+                try {
+                        // Mostrar loader al iniciar cualquier petición (a menos que se omita explícitamente)
+                        if (!shouldSkipLoader) {
+                                showLoader("Procesando información...");
+                        }
 
-			return response;
-		} catch (err) {
-			// Aseguramos ocultar el loader también en caso de error
-			hideLoader();
-			throw err;
-		}
-	};
+                        // Ejecutar la petición real
+                        const response = await _fetch(resource, fetchOptions);
+
+                        // Ocultar loader al terminar
+                        if (!shouldSkipLoader) {
+                                hideLoader();
+                        }
+
+                        return response;
+                } catch (err) {
+                        // Aseguramos ocultar el loader también en caso de error
+                        if (!shouldSkipLoader) {
+                                hideLoader();
+                        }
+                        throw err;
+                }
+        };
 });
 document.addEventListener("DOMContentLoaded", () => {
 	// Selecciona todos los forms de cambiar archivo


### PR DESCRIPTION
## Summary
- add an opt-out flag to the global fetch wrapper so requests can skip the loader when requested
- ensure the IA chat view opts out of the loader by passing the new flag on its fetch call

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf75eff58c83239eca38226df0eb3f