### PR TITLE
Allow skipping loader for IA chat requests

### DIFF
--- a/Backend/admin/Views/ia/index.php
+++ b/Backend/admin/Views/ia/index.php
@@ -147,7 +147,7 @@ $iaChatUrl      = admin_url('/ia/chat');
                     : <?= json_encode($iaChatUrl, JSON_UNESCAPED_SLASHES) ?>;
 
                 const res = await fetch(chatEndpoint, {
-                    skipLoader: true,
+                    skipLoader: true, // Omitimos el loader global en el chat IA
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json"

--- a/Backend/admin/assets/main.js
+++ b/Backend/admin/assets/main.js
@@ -133,12 +133,16 @@ document.addEventListener("DOMContentLoaded", function () {
 
 	// Sobreescribimos fetch para mostrar/ocultar loader automáticamente
         window.fetch = async function (resource, options) {
-                const shouldSkipLoader = options?.skipLoader === true;
                 let fetchOptions = options;
+                let shouldSkipLoader = false;
 
-                if (options && typeof options === "object" && "skipLoader" in options) {
-                        const { skipLoader, ...rest } = options;
-                        fetchOptions = rest;
+                if (options && typeof options === "object") {
+                        shouldSkipLoader = options.skipLoader === true;
+
+                        if ("skipLoader" in options) {
+                                const { skipLoader, ...restOptions } = options;
+                                fetchOptions = restOptions;
+                        }
                 }
 
                 try {


### PR DESCRIPTION
## Summary
- update the global fetch wrapper to respect a `skipLoader` opt-out and strip the flag before delegating to the native implementation
- ensure the IA chat request opts out of the loader so that screen bypasses the global spinner

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf797e121c83238eec85cc3ef324e5