### PR TITLE
Actualizar enlaces de arrendadores en pólizas

### DIFF
--- a/Backend/admin/Controllers/ArrendadorController.php
+++ b/Backend/admin/Controllers/ArrendadorController.php
@@ -73,9 +73,18 @@ class ArrendadorController
     /**
      * Vista de detalle
      */
-    public function detalle(int $id)
+    public function detalle(string $slug)
     {
-        $arrendador = $this->model->obtenerPorId($id);
+        $slug = trim($slug);
+        $arrendador = $slug !== '' ? $this->model->obtenerPorSlug($slug) : null;
+
+        if (!$arrendador && preg_match('/-(\d+)$/', $slug, $matches)) {
+            $arrendador = $this->model->obtenerPorId((int) $matches[1]);
+        }
+
+        if (!$arrendador && ctype_digit($slug)) {
+            $arrendador = $this->model->obtenerPorId((int) $slug);
+        }
 
         if (!$arrendador) {
             http_response_code(404);

--- a/Backend/admin/Models/ArrendadorModel.php
+++ b/Backend/admin/Models/ArrendadorModel.php
@@ -115,6 +115,19 @@ class ArrendadorModel extends Database
         return $row ? $this->hydrateArrendador($row) : null;
     }
 
+    public function obtenerPorSlug(string $slug): ?array
+    {
+        $slug = trim($slug);
+        if ($slug === '') {
+            return null;
+        }
+
+        $sql = 'SELECT * FROM arrendadores WHERE slug = :slug LIMIT 1';
+        $row = $this->fetch($sql, [':slug' => $slug]);
+
+        return $row ? $this->hydrateArrendador($row) : null;
+    }
+
     public function obtenerProfilePorPk(string $pk): ?array
     {
         if (!preg_match('/^arr#(\d+)$/', $pk, $matches)) {

--- a/Backend/admin/Models/PolizaModel.php
+++ b/Backend/admin/Models/PolizaModel.php
@@ -253,6 +253,7 @@ class PolizaModel extends Database
             a.nombre_asesor AS nombre_asesor,
             a.celular AS celular_asesor,
             arr.nombre_arrendador AS nombre_arrendador,
+            arr.slug AS slug_arrendador,
             arr.celular AS celular_arrendador,
             arr.direccion_arrendador,
             arr.banco AS banco_arrendador,

--- a/Backend/admin/Views/polizas/detalle.php
+++ b/Backend/admin/Views/polizas/detalle.php
@@ -56,9 +56,15 @@
 
                 <div class="space-y-1 text-sm">
                     <div>
+                        <?php
+                        $slugArrendador = trim((string)($poliza['slug_arrendador'] ?? ''));
+                        $arrendadorHref = $slugArrendador !== ''
+                            ? $baseUrl . '/arrendadores/' . $slugArrendador
+                            : $baseUrl . '/arrendadores/' . $poliza['id_arrendador'];
+                        ?>
                         <p class="text-sm text-white">
                             <span class="font-semibold text-indigo-400">Arrendador:</span>
-                            <a href="<?= $baseUrl ?>/arrendadores/<?= $poliza['id_arrendador'] ?>"
+                            <a href="<?= htmlspecialchars($arrendadorHref) ?>"
                                 class="text-indigo-300 underline hover:text-indigo-100 transition font-medium ml-1"
                                 id="val-arrendador" target="_blank">
                                 <?= htmlspecialchars($poliza['nombre_arrendador']) ?>

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -192,9 +192,9 @@ switch (true) {
         break;
 
     // Arrendador detalle por slug
-    case preg_match('#^/arrendadores/([a-z0-9-]+)-([0-9]+)$#i', $uri, $m):
+    case preg_match('#^/arrendadores/(?!por-asesor(?:/|$))([a-z0-9-]+)$#i', $uri, $m):
         require __DIR__ . '/Controllers/ArrendadorController.php';
-        (new \App\Controllers\ArrendadorController())->detalle((int)$m[2]);
+        (new \App\Controllers\ArrendadorController())->detalle($m[1]);
         exit;
         break;
 


### PR DESCRIPTION
## Summary
- exponer el slug del arrendador en la consulta principal de pólizas
- actualizar la vista de detalle de pólizas para enlazar al arrendador por slug con retrocompatibilidad
- permitir que el detalle de arrendadores cargue por slug y ajustar la ruta correspondiente

## Testing
- php -l Backend/admin/Models/PolizaModel.php
- php -l Backend/admin/Views/polizas/detalle.php
- php -l Backend/admin/Models/ArrendadorModel.php
- php -l Backend/admin/Controllers/ArrendadorController.php
- php -l Backend/admin/router.php

------
https://chatgpt.com/codex/tasks/task_e_68cf835a1ca083239da1d70f30bcacaf