### PR TITLE
Agregar eliminación de póliza desde la vista de detalle

### DIFF
--- a/Backend/admin/Models/PolizaModel.php
+++ b/Backend/admin/Models/PolizaModel.php
@@ -729,4 +729,14 @@ class PolizaModel extends Database
 
         return $ok;
     }
+
+    public function eliminarPorNumero(int $numero): bool
+    {
+        $stmt = $this->db->prepare('DELETE FROM polizas WHERE numero_poliza = :numero LIMIT 1');
+        $stmt->execute([
+            ':numero' => $numero,
+        ]);
+
+        return $stmt->rowCount() > 0;
+    }
 }

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -358,6 +358,12 @@ switch (true) {
         exit;
         break;
 
+    case $uri === '/polizas/eliminar' && $_SERVER['REQUEST_METHOD'] === 'POST':
+        require __DIR__ . '/Controllers/PolizaController.php';
+        (new \App\Controllers\PolizaController())->eliminar();
+        exit;
+        break;
+
     case $uri === '/ia' && $_SERVER['REQUEST_METHOD'] === 'GET':
         require __DIR__ . '/Controllers/IAController.php';
         (new \Backend\admin\Controllers\IAController())->index();


### PR DESCRIPTION
## Summary
- unificar el estilo de los botones en la vista de detalle de pólizas y añadir la acción de eliminación con confirmación
- exponer endpoint y lógica en backend para borrar pólizas por número y permitir la redirección tras eliminar

## Testing
- php -l admin/Controllers/PolizaController.php
- php -l admin/Models/PolizaModel.php
- php -l admin/router.php

------
https://chatgpt.com/codex/tasks/task_e_68cf9074e17083239f40cb6f03e632b9