### PR TITLE
Ensure póliza deletion request keeps admin session

### DIFF
--- a/Backend/admin/Views/polizas/detalle.php
+++ b/Backend/admin/Views/polizas/detalle.php
@@ -289,7 +289,8 @@
                         headers: {
                             'Content-Type': 'application/json'
                         },
-                        body: JSON.stringify({ numero: POLIZA_NUM })
+                        body: JSON.stringify({ numero: POLIZA_NUM }),
+                        credentials: 'same-origin'
                     });
 
                     const data = await respuesta.json();


### PR DESCRIPTION
## Summary
- send session cookies with the fetch call that elimina pólizas so the backend does not redirect to login when Swal triggers the request

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf934fbb648323ad5d5a0739abd43b