### PR TITLE
Fix historial vivienda data binding

### DIFF
--- a/Backend/admin/Models/InquilinoModel.php
+++ b/Backend/admin/Models/InquilinoModel.php
@@ -201,7 +201,10 @@ class InquilinoModel extends Database
         $profile['direccion'] = $this->fetchDireccion($id);
         $profile['trabajo']   = $this->fetchTrabajo($id);
         $profile['fiador']    = $this->fetchFiador($id);
-        $profile['historial'] = $this->fetchHistorial($id);
+
+        $historialVivienda = $this->fetchHistorial($id);
+        $profile['historial'] = $historialVivienda;
+        $profile['historial_vivienda'] = $historialVivienda;
 
         return $profile;
     }


### PR DESCRIPTION
## Summary
- ensure the inquilino profile exposes historial_vivienda data when fetching records
- keep backwards compatibility by also storing the data under the existing historial key

## Testing
- php -l Backend/admin/Models/InquilinoModel.php

------
https://chatgpt.com/codex/tasks/task_e_68d063a724988323b6c8309aef684968