### PR TITLE
Fix tenant personal data update error

### DIFF
--- a/Backend/admin/Models/InquilinoModel.php
+++ b/Backend/admin/Models/InquilinoModel.php
@@ -691,7 +691,7 @@ class InquilinoModel extends Database
 
         $campos = [
             'tipo', 'nombre_inquilino', 'apellidop_inquilino', 'apellidom_inquilino',
-            'nombre', 'email', 'celular', 'estadocivil', 'nacionalidad', 'curp', 'rfc',
+            'email', 'celular', 'estadocivil', 'nacionalidad', 'curp', 'rfc',
             'tipo_id', 'num_id', 'slug', 'conyuge'
         ];
 


### PR DESCRIPTION
## Summary
- avoid updating the nonexistent `nombre` column when persisting tenant personal data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d065a76c0083238b72aae751829867