### PR TITLE
Corrige generación del slug de inquilinos

### DIFF
--- a/Backend/admin/Controllers/InquilinoController.php
+++ b/Backend/admin/Controllers/InquilinoController.php
@@ -84,8 +84,9 @@ class InquilinoController
 
             // 🔹 Slug amigable
             $pk = $inq['profile']['pk'] ?? '';   // ej. inq#1241 / obl#99 / fia#77
-            $id = str_replace(['inq#', 'obl#', 'fia#'], '', $pk);
-            $inq['profile']['slug'] = SlugHelper::fromName($nombreCompleto) . '-' . $id;
+            $id = trim(str_replace(['inq#', 'obl#', 'fia#'], '', (string) $pk));
+            $slugBase = SlugHelper::fromName($nombreCompleto);
+            $inq['profile']['slug'] = $id !== '' ? $id . '-' . $slugBase : $slugBase;
 
             // 🔹 Mantener limpio el resultado: solo profile + selfie_url
             $inq = [
@@ -147,7 +148,8 @@ class InquilinoController
         $numId     = NormalizadoHelper::lower(trim($_POST['num_id'] ?? ''));
 
         $nombreCompleto = trim($nombre . ' ' . $apPaterno . ' ' . $apMaterno);
-        $slug = SlugHelper::fromName($nombreCompleto !== '' ? $nombreCompleto : $pk) . '-' . $id;
+        $slugBase = SlugHelper::fromName($nombreCompleto !== '' ? $nombreCompleto : $pk);
+        $slug = $id > 0 ? $id . '-' . $slugBase : $slugBase;
 
         try {
             $ok = $this->model->actualizarDatosPersonalesPorPk($pk, [

--- a/Backend/admin/Controllers/InquilinoValidacionAWSController.php
+++ b/Backend/admin/Controllers/InquilinoValidacionAWSController.php
@@ -2104,7 +2104,9 @@ class InquilinoValidacionAWSController
                             ($inquilino['apellidop_inquilino'] ?? '') . ' ' .
                             ($inquilino['apellidom_inquilino'] ?? '')
                     );
-                    $slug = \App\Helpers\SlugHelper::fromName($nombreCompleto);
+                    $slugBase = \App\Helpers\SlugHelper::fromName($nombreCompleto);
+                    $idInquilino = (int) ($inquilino['id'] ?? 0);
+                    $slug = $idInquilino > 0 ? $idInquilino . '-' . $slugBase : $slugBase;
                 }
 
                 // Si el cliente quiere texto plano combinado (?plain=1)


### PR DESCRIPTION
## Summary
- asegura que los slugs recalculados de inquilinos conserven el identificador numérico al inicio
- ajusta el fallback de slug en las validaciones AWS para reutilizar el mismo formato

## Testing
- php -l Backend/admin/Controllers/InquilinoController.php
- php -l Backend/admin/Controllers/InquilinoValidacionAWSController.php

------
https://chatgpt.com/codex/tasks/task_e_68d069dd814483239a14bf29fca4a158