### PR TITLE
Fix arrendadores search parameters

### DIFF
--- a/Backend/admin/Models/ArrendadorModel.php
+++ b/Backend/admin/Models/ArrendadorModel.php
@@ -97,12 +97,16 @@ class ArrendadorModel extends Database
         $needle = '%' . NormalizadoHelper::lower($q) . '%';
 
         $sql = 'SELECT * FROM arrendadores
-                WHERE LOWER(nombre_arrendador) LIKE :needle
-                   OR LOWER(email) LIKE :needle
-                   OR LOWER(celular) LIKE :needle
+                WHERE LOWER(nombre_arrendador) LIKE :needle_nombre
+                   OR LOWER(email) LIKE :needle_email
+                   OR LOWER(celular) LIKE :needle_celular
                 ORDER BY fecha_registro DESC';
 
-        $rows = $this->fetchAll($sql, [':needle' => $needle]);
+        $rows = $this->fetchAll($sql, [
+            ':needle_nombre'  => $needle,
+            ':needle_email'   => $needle,
+            ':needle_celular' => $needle,
+        ]);
 
         return array_map(fn(array $row): array => $this->hydrateArrendador($row), $rows);
     }


### PR DESCRIPTION
## Summary
- adjust the arrendadores search query to use unique named placeholders compatible with native PDO prepares
- reuse the normalized search term across each field-specific placeholder when executing the query

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0e544ee888323b7e03a82b8f9e17f