### PR TITLE
Fix arrendador detail redirect after slug update

### DIFF
--- a/Backend/admin/Controllers/ArrendadorController.php
+++ b/Backend/admin/Controllers/ArrendadorController.php
@@ -229,11 +229,19 @@ class ArrendadorController
             'num_id'               => NormalizadoHelper::lower($_POST['num_id'] ?? ''),
         ];
 
-        $ok = $this->model->actualizarDatosPersonales($pk, $data);
+        $slugActualizado = $this->model->actualizarDatosPersonales($pk, $data);
+
+        if ($slugActualizado === null) {
+            echo json_encode([
+                'ok'    => false,
+                'error' => 'No se pudo actualizar'
+            ]);
+            return;
+        }
 
         echo json_encode([
-            'ok'    => $ok,
-            'error' => $ok ? null : 'No se pudo actualizar'
+            'ok'   => true,
+            'slug' => $slugActualizado,
         ]);
     }
 

--- a/Backend/admin/Models/ArrendadorModel.php
+++ b/Backend/admin/Models/ArrendadorModel.php
@@ -254,10 +254,10 @@ class ArrendadorModel extends Database
         return true;
     }
 
-    public function actualizarDatosPersonales(string $pk, array $data): bool
+    public function actualizarDatosPersonales(string $pk, array $data): ?string
     {
         if (!preg_match('/^arr#(\d+)$/', $pk, $matches)) {
-            return false;
+            return null;
         }
 
         $id = (int)$matches[1];
@@ -291,7 +291,7 @@ class ArrendadorModel extends Database
             ':id'                => $id,
         ]);
 
-        return true;
+        return $slug;
     }
 
     public function actualizarInfoBancaria(int $id, array $data): bool

--- a/Backend/admin/assets/propietarioDetalles.js
+++ b/Backend/admin/assets/propietarioDetalles.js
@@ -79,29 +79,48 @@ document.addEventListener("DOMContentLoaded", () => {
 			body: data,
 		})
 			.then((r) => r.json())
-			.then((res) => {
-				if (res.ok) {
-					Swal.fire({
-						icon: "success",
-						title: "¡Actualizado!",
-						text: "Info actualizada exitosamente.",
-						background: "#1f1f2e",
-						color: "#fde8e8ca",
-						iconColor: "#a5b4fc",
-						showConfirmButton: false,
-						timer: 2000,
-						position: "center",
-						customClass: {
-							popup: "rounded-2xl shadow-lg border border-indigo-500/30",
-						},
-					});
-					setTimeout(() => location.reload(), 2000);
-				} else {
-					Swal.fire({
-						icon: "error",
-						title: "Error",
-						text: res.error || "No se pudo guardar",
-					});
+                        .then((res) => {
+                                if (res.ok) {
+                                        Swal.fire({
+                                                icon: "success",
+                                                title: "¡Actualizado!",
+                                                text: "Info actualizada exitosamente.",
+                                                background: "#1f1f2e",
+                                                color: "#fde8e8ca",
+                                                iconColor: "#a5b4fc",
+                                                showConfirmButton: false,
+                                                timer: 2000,
+                                                position: "center",
+                                                customClass: {
+                                                        popup: "rounded-2xl shadow-lg border border-indigo-500/30",
+                                                },
+                                        });
+
+                                        const nuevaRuta = (() => {
+                                                if (!res.slug) {
+                                                        return null;
+                                                }
+
+                                                if (typeof window.joinAdmin === "function") {
+                                                        return window.joinAdmin(`arrendadores/${res.slug}`);
+                                                }
+
+                                                return `${BASE_URL}/arrendadores/${res.slug}`;
+                                        })();
+
+                                        setTimeout(() => {
+                                                if (nuevaRuta) {
+                                                        window.location.href = nuevaRuta;
+                                                } else {
+                                                        window.location.reload();
+                                                }
+                                        }, 2000);
+                                } else {
+                                        Swal.fire({
+                                                icon: "error",
+                                                title: "Error",
+                                                text: res.error || "No se pudo guardar",
+                                        });
 				}
 			});
 	};


### PR DESCRIPTION
## Summary
- return the refreshed slug from `ArrendadorModel::actualizarDatosPersonales`
- ensure the arrendador controller responds with the new slug after updating
- adjust the detalle view script to redirect to the updated slug when datos personales change

## Testing
- php -l Backend/admin/Controllers/ArrendadorController.php
- php -l Backend/admin/Models/ArrendadorModel.php

------
https://chatgpt.com/codex/tasks/task_e_68d0ecc470b48323b96ad14891e96975