### PR TITLE
Add policy detail link to landlord detail view

### DIFF
--- a/Backend/admin/Views/arrendadores/detalle.php
+++ b/Backend/admin/Views/arrendadores/detalle.php
@@ -259,7 +259,6 @@ use App\Helpers\TextHelper;
     <div class="bg-gray-900 p-6 rounded-xl shadow-xl">
         <div class="flex items-center justify-between mb-4">
             <h2 class="text-xl font-semibold text-indigo-400">Pólizas registradas</h2>
-            <p>** Regresar acá y hacer que las pólizas tengas enlace a su detalle</p>
         </div>
         <div class="grid md:grid-cols-2 gap-6">
             <?php foreach ($arrendador['polizas'] as $p): ?>
@@ -267,6 +266,12 @@ use App\Helpers\TextHelper;
                     <p><span class="font-semibold text-indigo-200">Número:</span> <?= htmlspecialchars($p['numero_poliza']) ?></p>
                     <p><span class="font-semibold text-indigo-200">Tipo:</span> <?= TextHelper::titleCase($p['tipo_poliza']) ?></p>
                     <p><span class="font-semibold text-indigo-200">Vigencia:</span> <?= TextHelper::titleCase($p['vigencia']) ?></p>
+                    <div class="flex justify-center pt-2">
+                        <a href="<?= $baseUrl ?>/admin/polizas/<?= rawurlencode($p['numero_poliza']) ?>"
+                            class="inline-flex w-full sm:w-auto justify-center px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg font-medium text-sm transition">
+                            Ver detalle
+                        </a>
+                    </div>
                 </div>
             <?php endforeach; ?>
         </div>


### PR DESCRIPTION
## Summary
- add a "Ver detalle" button to each póliza card in the arrendador detail view
- link each button to the corresponding póliza detail page and style it responsively for desktop and mobile

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0ee47cce88323a89e040d4bd143c9