### PR TITLE
Ajusta mapeo de estado VerificaMex

### DIFF
--- a/Backend/admin/Controllers/InquilinoValidacionAWSController.php
+++ b/Backend/admin/Controllers/InquilinoValidacionAWSController.php
@@ -167,13 +167,20 @@ class InquilinoValidacionAWSController
             $model->guardarValidacionesVerificaMex($idInquilino, $campos);
 
             // 📌 Status/resumen general
-            $status  = !empty($json['data']['status']) ? 1 : 0;
-            $resumen = $status === 1
-                ? "✔️ INE válida (VerificaMex)"
-                : ("❌ " . ($json['message'] ?? "Error en validación"));
+            $statusFlag = filter_var($json['data']['status'] ?? false, FILTER_VALIDATE_BOOLEAN);
+            $proceso = $statusFlag ? 1 : 2;
+            $status = $statusFlag ? 1 : 0;
+            $mensaje = trim((string) ($json['message'] ?? 'Mensaje no disponible'));
+            if ($mensaje === '') {
+                $mensaje = 'Mensaje no disponible';
+            }
+
+            $resumen = $statusFlag
+                ? "☑️ {$mensaje}"
+                : "✖️ Se rechazó la credencial, el servidor INE regresó el siguiente mensaje: {$mensaje}";
 
             // Guardar también el JSON limpio completo
-            $ok = $model->guardarValidacionVerificaMex($idInquilino, $status, $jsonLimpio, $resumen);
+            $ok = $model->guardarValidacionVerificaMex($idInquilino, $proceso, $jsonLimpio, $resumen);
 
             // 🔄 Devolver todo, igual que en mock
             return [


### PR DESCRIPTION
## Summary
- mapea el estado devuelto por VerificaMex a los códigos de proceso 1/2 para la columna proceso_validacion_verificamex
- ajusta el resumen de VerificaMex con los textos requeridos en función del resultado y usa mensajes por defecto cuando falte el texto original

## Testing
- php -l Backend/admin/Controllers/InquilinoValidacionAWSController.php

------
https://chatgpt.com/codex/tasks/task_e_68d1d251bbd88323bd55a43407a47436