### PR TITLE
Ajusta validación de identidad con reglas de VerificaMex

### DIFF
--- a/Backend/admin/Helpers/VerificaMexMapper.php
+++ b/Backend/admin/Helpers/VerificaMexMapper.php
@@ -40,49 +40,136 @@ class VerificaMexMapper
 
         // --- 2. Nombre / Identidad ---
         $nombreIne = null;
+        $ineNombre = null;
+        $ineApellidos = [];
         if (!empty($json['data']['documentInformation']['documentData'])) {
-            $partes = [];
             foreach ($json['data']['documentInformation']['documentData'] as $dato) {
-                $tipo = $dato['type'] ?? '';
-                $valor = trim($dato['value'] ?? '');
-                if ($valor === '') continue;
+                $valor = trim((string) ($dato['value'] ?? ''));
+                if ($valor === '') {
+                    continue;
+                }
 
-                if (in_array($tipo, ['Surname', 'SecondSurname', 'FatherSurname', 'MotherSurname', 'Name'], true)) {
-                    $partes[] = $valor;
+                $etiqueta = strtolower(trim((string) ($dato['name'] ?? '')));
+                if ($etiqueta === 'nombre') {
+                    $ineNombre = $valor;
+                }
+                if ($etiqueta === 'apellido/s') {
+                    $ineApellidos[] = $valor;
                 }
             }
-            if (!empty($partes)) {
-                $nombreIne = implode(' ', $partes);
-            }
+
+            $ineApellidos = array_values(array_unique($ineApellidos));
+            $nombreIne = trim(implode(' ', array_filter([
+                trim(implode(' ', $ineApellidos)),
+                $ineNombre,
+            ])));
         }
 
         if ($nombreIne && $inquilino) {
             // Normalización de cadenas (acentos, ñ, mayúsculas, espacios)
             $normalize = function ($string) {
-                $string = mb_strtoupper($string, 'UTF-8');
-                $string = iconv('UTF-8', 'ASCII//TRANSLIT', $string); // quita acentos y ñ → N
-                $string = str_replace(["´", "‘", "’", "`"], "", $string); // quita comillas raras
-                $string = preg_replace('/[^A-Z ]/', '', $string); // solo letras y espacios
-                $string = preg_replace('/\s+/', ' ', trim($string));
-                return $string;
+                $string = trim((string) $string);
+                if ($string === '') {
+                    return '';
+                }
+
+                $string = mb_strtolower($string, 'UTF-8');
+                $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT', $string);
+                if ($transliterated !== false) {
+                    $string = $transliterated;
+                }
+                $string = preg_replace('/[^a-z\s]/', '', $string) ?? '';
+                $string = preg_replace('/\s+/', ' ', $string) ?? '';
+
+                return trim($string);
             };
 
-            $nombreBD = $normalize(
-                ($inquilino['apellidop_inquilino'] ?? '') . ' ' .
-                    ($inquilino['apellidom_inquilino'] ?? '') . ' ' .
-                    ($inquilino['nombre_inquilino'] ?? '')
-            );
+            $nombreBdOriginal = trim(implode(' ', array_filter([
+                $inquilino['apellidop_inquilino'] ?? '',
+                $inquilino['apellidom_inquilino'] ?? '',
+                $inquilino['nombre_inquilino'] ?? '',
+            ])));
+
+            $nombreIneOriginal = $nombreIne;
+
+            $nombreBD = $normalize($nombreBdOriginal);
             $nombreIne = $normalize($nombreIne);
 
-            $coincide = (strpos($nombreBD, $nombreIne) !== false || strpos($nombreIne, $nombreBD) !== false);
+            $similaridad = null;
+            if ($nombreBD !== '' && $nombreIne !== '') {
+                $percent = 0.0;
+                similar_text($nombreBD, $nombreIne, $percent);
+                $similaridad = round($percent, 2);
+            }
 
-            $campos['proceso_validacion_id'] = $coincide ? 1 : 0;
-            $campos['validacion_id_resumen'] = $coincide
-                ? "✔️ Identidad (nombres): coincide con BD ($nombreIne)"
-                : "❌ Identidad: no coincide (INE=$nombreIne, BD=$nombreBD)";
+            $nombreCoincide = ($similaridad !== null && $similaridad >= 90.0);
+
+            $faceComparison = $json['data']['faceComparison'] ?? null;
+            $faceResult = null;
+            $faceSimilarity = null;
+            if (is_array($faceComparison)) {
+                $faceResult = filter_var($faceComparison['result'] ?? null, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                if (isset($faceComparison['similarity'])) {
+                    $faceSimilarity = (float) $faceComparison['similarity'];
+                }
+            }
+            $rostroCoincide = ($faceResult === true);
+
+            $statusData = filter_var($json['data']['status'] ?? null, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            $statusRenapo = filter_var($json['data']['renapo']['status'] ?? null, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            $estatusDataOk = ($statusData === true);
+            $estatusRenapoOk = ($statusRenapo === true);
+
+            $todosOk = ($nombreCoincide && $rostroCoincide && $estatusDataOk && $estatusRenapoOk);
+
+            $campos['proceso_validacion_id'] = $todosOk ? 1 : 2;
+
+            $emojiNombre = $nombreCoincide ? '☑️' : '✖️';
+            $emojiRostro = $rostroCoincide ? '☑️' : '✖️';
+            $emojiStatus = ($estatusDataOk && $estatusRenapoOk) ? '☑️' : '✖️';
+
+            $similaridadTexto = $similaridad !== null ? number_format($similaridad, 2) . '%' : 'sin datos';
+            $similaridadRostroTexto = $faceSimilarity !== null ? number_format($faceSimilarity, 2) . '%' : 'sin datos';
+            $resultadoRostroTexto = $faceResult === null ? 'sin resultado' : ($faceResult ? 'aprobada' : 'rechazada');
+            $statusDataTexto = $statusData === null ? 'sin dato' : ($estatusDataOk ? 'aprobado' : 'rechazado');
+            $statusRenapoTexto = $statusRenapo === null ? 'sin dato' : ($estatusRenapoOk ? 'aprobado' : 'rechazado');
+
+            $campos['validacion_id_resumen'] = implode("\n", [
+                sprintf('%s Coincidencia de nombre BD vs INE: %s', $emojiNombre, $similaridadTexto),
+                sprintf('%s Coincidencia facial: %s (%s)', $emojiRostro, $resultadoRostroTexto, $similaridadRostroTexto),
+                sprintf('%s Estatus VerificaMex: data.status %s · renapo.status %s', $emojiStatus, $statusDataTexto, $statusRenapoTexto),
+            ]);
+
+            $fechaHoraMx = (new \DateTimeImmutable('now', new \DateTimeZone('America/Mexico_City')))->format(DATE_ATOM);
+
             $campos['validacion_id_json'] = [
-                'ine' => $nombreIne,
-                'bd'  => $nombreBD,
+                'timestamp' => $fechaHoraMx,
+                'timezone' => 'America/Mexico_City',
+                'nombre' => [
+                    'bd' => [
+                        'original' => $nombreBdOriginal,
+                        'normalizado' => $nombreBD,
+                    ],
+                    'ine' => [
+                        'original' => $nombreIneOriginal,
+                        'normalizado' => $nombreIne,
+                    ],
+                    'similaridad' => $similaridad,
+                    'umbral' => 90,
+                ],
+                'faceComparison' => [
+                    'result' => $faceResult,
+                    'similarity' => $faceSimilarity,
+                    'detalles' => $faceComparison,
+                ],
+                'status' => [
+                    'data' => $estatusDataOk,
+                    'renapo' => $estatusRenapoOk,
+                    'detalles' => [
+                        'data_raw' => $json['data']['status'] ?? null,
+                        'renapo_raw' => $json['data']['renapo']['status'] ?? null,
+                    ],
+                ],
             ];
         }
 


### PR DESCRIPTION
## Summary
- Normaliza los nombres de BD e INE usando solo los campos Nombre y Apellido/s en minúsculas sin acentos.
- Calcula el porcentaje de similitud y combina los resultados de rostro, data.status y renapo.status para definir el proceso y el resumen con emojis.
- Guarda un JSON estructurado con detalles completos y marca de tiempo de México antes de llamar a guardarValidacionIdentidad.

## Testing
- php -l admin/Helpers/VerificaMexMapper.php

------
https://chatgpt.com/codex/tasks/task_e_68d1d5132ff08323a5df4582078645d0