### PR TITLE
Prioritize VerificaMex data message

### DIFF
--- a/Backend/admin/Controllers/InquilinoValidacionAWSController.php
+++ b/Backend/admin/Controllers/InquilinoValidacionAWSController.php
@@ -201,7 +201,8 @@ class InquilinoValidacionAWSController
             $statusFlag = filter_var($json['data']['status'] ?? false, FILTER_VALIDATE_BOOLEAN);
             $proceso = $statusFlag ? 1 : 2;
             $status = $statusFlag ? 1 : 0;
-            $mensaje = trim((string) ($json['message'] ?? 'Mensaje no disponible'));
+            $mensajeFuente = $json['data']['message'] ?? $json['message'] ?? '';
+            $mensaje = trim((string) $mensajeFuente);
             if ($mensaje === '') {
                 $mensaje = 'Mensaje no disponible';
             }


### PR DESCRIPTION
## Summary
- prioritize the data.message field from VerificaMex responses when building the validation summary
- keep trimming and fallback to the legacy message field and default copy when no message is present

## Testing
- not run (project has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d1e45ace688323a0b1bdf87762ec18