### PR TITLE
Normalize mantenimiento values to Si/No/na

### DIFF
--- a/Backend/admin/Controllers/InmuebleController.php
+++ b/Backend/admin/Controllers/InmuebleController.php
@@ -370,6 +370,23 @@ class InmuebleController
         return $this->prepareInmueblePayload($_POST, $isUpdate);
     }
 
+    private function normalizarMantenimiento(string $valor): string
+    {
+        $normalizado = strtoupper(str_replace(' ', '_', trim($valor)));
+
+        switch ($normalizado) {
+            case 'SI':
+                return 'Si';
+            case 'NO':
+                return 'No';
+            case 'NO_APLICA':
+            case 'NA':
+                return 'na';
+            default:
+                return 'No';
+        }
+    }
+
     /**
      * @param array<string, mixed> $input
      * @return array<string, mixed>
@@ -416,8 +433,7 @@ class InmuebleController
             throw new \InvalidArgumentException('Faltan datos obligatorios del inmueble');
         }
 
-        $mantenimientoRaw = strtoupper(trim((string)($input['mantenimiento'] ?? 'NO')));
-        $mantenimiento    = $mantenimientoRaw === 'SI' ? 'SI' : 'NO';
+        $mantenimiento = $this->normalizarMantenimiento((string)($input['mantenimiento'] ?? ''));
 
         $montoMantenimiento = $this->normalizarMonto((string)($input['monto_mantenimiento'] ?? '0'));
         $deposito           = $this->normalizarMonto((string)($input['deposito'] ?? '0'));

--- a/Backend/admin/Models/InmueblesModel.php
+++ b/Backend/admin/Models/InmueblesModel.php
@@ -143,7 +143,7 @@ class InmuebleModel extends Database
         $idAsesor      = isset($item['id_asesor']) ? (int) $item['id_asesor'] : null;
         $pk            = $idArrendador > 0 ? self::ARRENDADOR_PK_PREFIX . $idArrendador : '';
         $sk            = $id > 0 ? self::INMUEBLE_SK_PREFIX . $id : '';
-        $mantenimiento = strtoupper((string) ($item['mantenimiento'] ?? 'NO'));
+        $mantenimiento = $this->normalizarMantenimiento((string) ($item['mantenimiento'] ?? 'NO'));
         $mascotas      = strtoupper((string) ($item['mascotas'] ?? 'NO'));
 
         $inmueble = [
@@ -156,7 +156,7 @@ class InmuebleModel extends Database
             'tipo'                => (string) ($item['tipo'] ?? ''),
             'direccion_inmueble'  => (string) ($item['direccion_inmueble'] ?? ''),
             'renta'               => $this->formatearMonto($item['renta'] ?? null),
-            'mantenimiento'       => $mantenimiento === 'SI' ? 'SI' : 'NO',
+            'mantenimiento'       => $mantenimiento,
             'monto_mantenimiento' => $this->formatearMonto($item['monto_mantenimiento'] ?? null),
             'deposito'            => $this->formatearMonto($item['deposito'] ?? null),
             'estacionamiento'     => (int) ($item['estacionamiento'] ?? 0),
@@ -169,6 +169,23 @@ class InmuebleModel extends Database
         ];
 
         return $inmueble;
+    }
+
+    private function normalizarMantenimiento(string $valor): string
+    {
+        $normalizado = strtoupper(str_replace(' ', '_', trim($valor)));
+
+        switch ($normalizado) {
+            case 'SI':
+                return 'Si';
+            case 'NO':
+                return 'No';
+            case 'NO_APLICA':
+            case 'NA':
+                return 'na';
+            default:
+                return 'No';
+        }
     }
 
     /**

--- a/Backend/admin/Views/arrendadores/detalle.php
+++ b/Backend/admin/Views/arrendadores/detalle.php
@@ -357,9 +357,9 @@ use App\Helpers\TextHelper;
                 <input type="number" name="renta" placeholder="Renta mensual (MXN)" class="w-full px-3 py-2 rounded-lg bg-[#232336] border border-indigo-800 text-indigo-100">
                 <select name="mantenimiento" class="w-full px-3 py-2 rounded-lg bg-[#232336] border border-indigo-800 text-indigo-100">
                     <option value="">¿Incluye mantenimiento?</option>
-                    <option value="Sí">Sí</option>
+                    <option value="Si">Si</option>
                     <option value="No">No</option>
-                    <option value="No Aplica">No Aplica</option>
+                    <option value="na">No Aplica</option>
                 </select>
             </div>
 
@@ -463,8 +463,9 @@ use App\Helpers\TextHelper;
                     <div>
                         <label class="block text-sm text-indigo-200 mb-1" for="edit-mantenimiento">¿Incluye mantenimiento?</label>
                         <select id="edit-mantenimiento" name="mantenimiento" class="w-full rounded-lg px-4 py-2 bg-[#232336] text-indigo-100 border border-indigo-800 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                            <option value="NO">No</option>
-                            <option value="SI">Sí</option>
+                            <option value="Si">Si</option>
+                            <option value="No">No</option>
+                            <option value="na">No Aplica</option>
                         </select>
                     </div>
                     <div>

--- a/Backend/admin/Views/inmuebles/form.php
+++ b/Backend/admin/Views/inmuebles/form.php
@@ -52,8 +52,9 @@ foreach ($asesores as $asesor) {
             <div>
                 <label class="block text-indigo-300 mb-1">¿Incluye Mantenimiento?</label>
                 <select name="mantenimiento" class="w-full rounded-lg px-4 py-2 bg-[#232336] text-indigo-100 border border-indigo-800" required>
-                    <option value="SI" <?= ($inmueble['mantenimiento'] ?? '') === 'SI' ? 'selected' : '' ?>>Sí</option>
-                    <option value="NO" <?= ($inmueble['mantenimiento'] ?? '') === 'NO' ? 'selected' : '' ?>>No</option>
+                    <option value="Si" <?= ($inmueble['mantenimiento'] ?? '') === 'Si' ? 'selected' : '' ?>>Si</option>
+                    <option value="No" <?= ($inmueble['mantenimiento'] ?? '') === 'No' ? 'selected' : '' ?>>No</option>
+                    <option value="na" <?= ($inmueble['mantenimiento'] ?? '') === 'na' ? 'selected' : '' ?>>No Aplica</option>
                 </select>
             </div>
 

--- a/Backend/admin/assets/propietarioDetalles.js
+++ b/Backend/admin/assets/propietarioDetalles.js
@@ -356,8 +356,28 @@ document.addEventListener("DOMContentLoaded", () => {
 
                 const mantenimiento = formEditarInmueble.querySelector('#edit-mantenimiento');
                 if (mantenimiento) {
-                        const value = typeof data.mantenimiento === "string" ? data.mantenimiento.toUpperCase() : "";
-                        mantenimiento.value = value === "SI" ? "SI" : "NO";
+                        const rawValue = typeof data.mantenimiento === "string"
+                                ? data.mantenimiento
+                                : "";
+                        const normalizado = rawValue.toUpperCase().replace(/\s+/g, '_').trim();
+
+                        let valorSelect = "No";
+                        switch (normalizado) {
+                                case "SI":
+                                        valorSelect = "Si";
+                                        break;
+                                case "NO":
+                                        valorSelect = "No";
+                                        break;
+                                case "NO_APLICA":
+                                case "NA":
+                                        valorSelect = "na";
+                                        break;
+                                default:
+                                        valorSelect = "No";
+                        }
+
+                        mantenimiento.value = valorSelect;
                 }
 
                 const montoMantenimiento = formEditarInmueble.querySelector('#edit-monto-mantenimiento');


### PR DESCRIPTION
## Summary
- normalize mantenimiento values on the controller and model so they are persisted as "Si", "No" or "na"
- update inmueble creation and edit forms (including arrendador flow) to use the requested option values
- keep the propietario details modal in sync by mapping legacy values to the new select values

## Testing
- php -l Backend/admin/Controllers/InmuebleController.php
- php -l Backend/admin/Models/InmueblesModel.php
- php -l Backend/admin/Views/inmuebles/form.php
- php -l Backend/admin/Views/arrendadores/detalle.php

------
https://chatgpt.com/codex/tasks/task_e_68d2055958e88323b9040b238fa52d6a