### PR TITLE
Actualizar vigencia automática al editar pólizas

### DIFF
--- a/Backend/admin/Views/polizas/editar.php
+++ b/Backend/admin/Views/polizas/editar.php
@@ -110,7 +110,7 @@
 
             <div>
                 <label class="block text-indigo-300 mb-1">Vigencia (texto)</label>
-                <input type="text" name="vigencia" value="<?= htmlspecialchars($poliza['vigencia']) ?>"
+                <input type="text" name="vigencia" id="vigencia-texto" value="<?= htmlspecialchars($poliza['vigencia']) ?>"
                     class="appearance-none w-full px-4 py-2 rounded-lg bg-[#232336] border border-indigo-800 text-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
             </div>
 

--- a/Backend/admin/assets/polizas.js
+++ b/Backend/admin/assets/polizas.js
@@ -99,6 +99,7 @@
                 const montoPoliza = document.getElementById("monto-poliza");
                 const fechaInicio = document.getElementById("fecha-inicio");
                 const fechaFin = document.getElementById("fecha-fin");
+                const vigenciaText = document.getElementById("vigencia-texto");
                 const numeroPolizaInput = form.querySelector('input[name="numero_poliza"]');
 
                 let montoPolizaEditadoManualmente = false;
@@ -259,8 +260,24 @@
 
                 // Fechas
                 fechaInicio?.addEventListener("change", () =>
-                        setFechaFinYVigencia({ inicioEl: fechaInicio, finEl: fechaFin })
+                        setFechaFinYVigencia({
+                                inicioEl: fechaInicio,
+                                finEl: fechaFin,
+                                vigenciaEl: vigenciaText,
+                        })
                 );
+                fechaFin?.addEventListener("change", () =>
+                        setFechaFinYVigencia({
+                                inicioEl: fechaInicio,
+                                finEl: fechaFin,
+                                vigenciaEl: vigenciaText,
+                        })
+                );
+                setFechaFinYVigencia({
+                        inicioEl: fechaInicio,
+                        finEl: fechaFin,
+                        vigenciaEl: vigenciaText,
+                });
                 // inicial
                 actualizarDisplayRenta(obtenerRentaLimpia(rentaHidden?.value));
                 if (!montoPoliza?.value) {


### PR DESCRIPTION
## Summary
- agregar el identificador `vigencia-texto` al campo de vigencia en la vista de edición de pólizas
- actualizar los listeners de fechas en el script de pólizas para recalcular también el texto de vigencia y rellenarlo al cargar el formulario

## Testing
- no se ejecutaron pruebas (no existen pruebas automatizadas)


------
https://chatgpt.com/codex/tasks/task_e_68d20a19f5048323a56de6893196ef8e