### PR TITLE
Ensure WhatsApp URL uses UTF-8 encoded message

### DIFF
--- a/Backend/admin/Views/dashboard/index.php
+++ b/Backend/admin/Views/dashboard/index.php
@@ -287,7 +287,7 @@ use App\Helpers\TextHelper;
                     // Codificar en UTF-8 antes de urlencode
                     $mensajeUtf8 = mb_convert_encoding($mensaje, 'UTF-8', 'auto');
 
-                    $waUrl = 'https://wa.me/+52' . $asesorTelefono . '?text=' . urlencode($mensaje);
+                    $waUrl = 'https://wa.me/+52' . $asesorTelefono . '?text=' . urlencode($mensajeUtf8);
 
 
                     $fechaVencimiento = null;


### PR DESCRIPTION
## Summary
- update the WhatsApp link builder to encode the already UTF-8 converted message

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d22878232483239fa59bc0aff5a2e3