### PR TITLE
Agrega marcador de fiador en contratos generados

### DIFF
--- a/Backend/admin/Controllers/PolizaController.php
+++ b/Backend/admin/Controllers/PolizaController.php
@@ -910,6 +910,7 @@ TXT;
 
         $set('ARRENDADOR',        $mayus($arrendador));
         $set('ARRENDATARIO',      $mayus($inquilino));
+        $set('FIADOR',            $mayus($fiador !== '' ? $fiador : 'N/A'));
         $set('OBLIGADO SOLIDARIO', $mayus($obligadoSolidario));
         $set('INMUEBLE',          $mayus($poliza['direccion_inmueble'] ?? ''));
         $set('ESTACIONAMIENTO',   $textoCajones($poliza['estacionamiento_inmueble'] ?? 0));


### PR DESCRIPTION
## Summary
- agrega la sustitución del marcador FIADOR al generar contratos desde el formulario

## Testing
- no se corrieron pruebas automatizadas; no hay suites definidas

------
https://chatgpt.com/codex/tasks/task_e_68d2aa8eddb88323b5f4b47aec8cf4a3