### PR TITLE
Ajusta direccion de garantia para fiador PF

### DIFF
--- a/Backend/admin/Controllers/PolizaController.php
+++ b/Backend/admin/Controllers/PolizaController.php
@@ -946,17 +946,12 @@ TXT;
                 }
             };
 
-            $append('calle_inmueble');
-            $append('num_ext_inmueble');
-
-            $numInt = trim((string)($poliza['num_int_inmueble'] ?? ''));
-            if ($numInt !== '') {
-                $dirPartes[] = $numInt;
-            }
-
-            $append('colonia_inmueble');
-            $append('alcaldia_inmueble');
-            $append('estado_inmueble');
+            $append('fiador_calle_garantia');
+            $append('fiador_num_ext_garantia');
+            $append('fiador_num_int_garantia');
+            $append('fiador_colonia_garantia');
+            $append('fiador_alcaldia_garantia');
+            $append('fiador_estado_garantia');
 
             $dirGarantia = $dirPartes !== []
                 ? mb_strtoupper(implode(' ', $dirPartes), 'UTF-8')


### PR DESCRIPTION
## Summary
- actualizar la construcción de la dirección de garantía en contratos fiador_pf para tomar los campos específicos del inmueble en garantía

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2adcfda048323a4c6044bd9c179ff