### PR TITLE
Ajusta datos de escritura del fiador en plantillas

### DIFF
--- a/Backend/admin/Controllers/PolizaController.php
+++ b/Backend/admin/Controllers/PolizaController.php
@@ -966,22 +966,33 @@ TXT;
                 return $mayus($valor);
             };
 
-            $fechaEscritura = trim((string)($poliza['fecha_escritura'] ?? ''));
-            if ($fechaEscritura !== '') {
-                $fechaObj = date_create($fechaEscritura);
+            $fechaEscritura = 'N/A';
+            $fechaEscrituraRaw = '';
+
+            if (array_key_exists('fiador_fecha_escritura', $poliza)) {
+                $fechaEscrituraRaw = trim((string)($poliza['fiador_fecha_escritura'] ?? ''));
+            }
+
+            if ($fechaEscrituraRaw === '' && array_key_exists('fecha_escritura', $poliza)) {
+                $fechaEscrituraRaw = trim((string)($poliza['fecha_escritura'] ?? ''));
+            }
+
+            if ($fechaEscrituraRaw !== '') {
+                $fechaObj = date_create($fechaEscrituraRaw);
                 if ($fechaObj instanceof DateTime) {
-                    $fechaEscritura = $fechaObj->format('d/m/Y');
+                    $fechaEscritura = $mayus($fechaObj->format('d/m/Y'));
+                } else {
+                    $fechaEscritura = $mayus($fechaEscrituraRaw);
                 }
             }
-            $fechaEscritura = $fechaEscritura !== '' ? $mayus($fechaEscritura) : 'N/A';
 
             $set('DIR_GARANTIA', $dirGarantia);
-            $set('ESCRITURA', $normaliza('numero_escritura'));
+            $set('ESCRITURA', $normaliza('fiador_numero_escritura'));
             $set('FECHA_ESCRITURA', $fechaEscritura);
             $set('NOMBRE_NOTARIO', $normaliza('nombre_notario'));
-            $set('NUM_NOTARIO', $normaliza('numero_notario'));
-            $set('CIUDAD_NOTARIO', $normaliza('ciudad_notario'));
-            $set('FOLIO_REAL', $normaliza('folio_real'));
+            $set('NUM_NOTARIO', $normaliza('fiador_numero_notario'));
+            $set('CIUDAD_NOTARIO', $normaliza('fiador_estado_notario'));
+            $set('FOLIO_REAL', $normaliza('fiador_folio_real'));
         }
 
         // Vigencia


### PR DESCRIPTION
## Summary
- Leer los campos de datos de escritura del fiador específicos al generar el contrato tipo fiador_pf
- Priorizar la fecha de escritura del fiador y normalizarla antes de colocarla en la plantilla

## Testing
- php -l Backend/admin/Controllers/PolizaController.php

------
https://chatgpt.com/codex/tasks/task_e_68d2b4471d408323870cefc35c121d8e