### PR TITLE
Ajusta direccion de garantia para contrato fiador PF

### DIFF
--- a/Backend/admin/Controllers/PolizaController.php
+++ b/Backend/admin/Controllers/PolizaController.php
@@ -942,6 +942,9 @@ TXT;
             $append = function (string $campo) use (&$dirPartes, $poliza): void {
                 $valor = trim((string)($poliza[$campo] ?? ''));
                 if ($valor !== '') {
+                    if ($campo === 'fiador_cp_garantia') {
+                        $valor = 'C.P. ' . $valor;
+                    }
                     $dirPartes[] = $valor;
                 }
             };
@@ -952,10 +955,7 @@ TXT;
             $append('fiador_colonia_garantia');
             $append('fiador_alcaldia_garantia');
             $append('fiador_estado_garantia');
-            $cpGarantia = trim((string)($poliza['fiador_cp_garantia'] ?? ''));
-            if ($cpGarantia !== '') {
-                $dirPartes[] = 'C.P. ' . $cpGarantia;
-            }
+            $append('fiador_cp_garantia');
 
             $dirGarantia = $dirPartes !== []
                 ? mb_strtoupper(implode(' ', $dirPartes), 'UTF-8')


### PR DESCRIPTION
## Summary
- normaliza la agregación del C.P. en la dirección de la garantía del fiador dentro del contrato
- confirma que la plantilla de contrato de fiador ya contiene el marcador DIR_GARANTIA

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68d2f33114bc8323b216e3502a40d1a3