### PR TITLE
Add fiador address placeholder to contract generation

### DIFF
--- a/Backend/admin/Controllers/PolizaController.php
+++ b/Backend/admin/Controllers/PolizaController.php
@@ -931,6 +931,7 @@ TXT;
         $set('TIPO_ID_FIADOR', $normalizarTipoIdentificacion($poliza['tipo_id_fiador'] ?? ''));
         $set('NUM_ID_FIADOR',  $mayus($poliza['num_id_fiador'] ?? ''));
         $set('NACIONALIDAD_FIADOR', $mayus(trim((string)($poliza['nacionalidad_fiador'] ?? ''))));
+        $set('DIRECCION_FIADOR', $mayus($poliza['direccion_fiador'] ?? ''));
 
         $set('monto_renta',         $montoEnNumeroYTexto((float)($poliza['monto_renta'] ?? 0)));
         $set('monto_mantenimiento', $montoEnNumeroYTexto((float)($poliza['monto_mantenimiento'] ?? 0)));


### PR DESCRIPTION
## Summary
- populate the fiador address placeholder when generating contracts from the form
- confirm that the Contract_Fiador_PF 2025.docx template exposes the DIRECCION_FIADOR marker

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d2f44a320083239589fe26fdab1252