### PR TITLE
Formatear fecha de escritura en contratos

### DIFF
--- a/Backend/admin/Controllers/PolizaController.php
+++ b/Backend/admin/Controllers/PolizaController.php
@@ -989,7 +989,28 @@ TXT;
             if ($fechaEscrituraRaw !== '') {
                 $fechaObj = date_create($fechaEscrituraRaw);
                 if ($fechaObj instanceof DateTime) {
-                    $fechaEscritura = $mayus($fechaObj->format('d/m/Y'));
+                    $formatterMes = new IntlDateFormatter(
+                        'es_MX',
+                        IntlDateFormatter::FULL,
+                        IntlDateFormatter::NONE,
+                        'America/Mexico_City',
+                        IntlDateFormatter::GREGORIAN,
+                        'MMMM'
+                    );
+
+                    $mesFormateado = $formatterMes->format($fechaObj);
+
+                    if ($mesFormateado !== false) {
+                        $fechaFormateada = sprintf(
+                            '%s DE %s DE %s',
+                            $fechaObj->format('d'),
+                            $mesFormateado,
+                            $fechaObj->format('Y')
+                        );
+                        $fechaEscritura = $mayus($fechaFormateada);
+                    } else {
+                        $fechaEscritura = $mayus($fechaObj->format('d/m/Y'));
+                    }
                 } else {
                     $fechaEscritura = $mayus($fechaEscrituraRaw);
                 }


### PR DESCRIPTION
## Summary
- actualizar la generación del campo FECHA_ESCRITURA para desplegar la fecha con el mes en texto y en mayúsculas
- mantener un formato de fecha numérico como respaldo cuando la conversión con IntlDateFormatter falle

## Testing
- php -l Backend/admin/Controllers/PolizaController.php

------
https://chatgpt.com/codex/tasks/task_e_68d2fc248310832396b4e9fa94423da4