### PR TITLE
Normalize person and address fields to title case before persistence

### DIFF
--- a/Backend/admin/Models/ArrendadorModel.php
+++ b/Backend/admin/Models/ArrendadorModel.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../Helpers/SlugHelper.php';
 use App\Core\Database;
 use App\Helpers\NormalizadoHelper;
 use App\Helpers\SlugHelper;
+use App\Helpers\TextHelper;
 use RuntimeException;
 
 class ArrendadorModel extends Database
@@ -262,7 +263,10 @@ class ArrendadorModel extends Database
 
         $id = (int)$matches[1];
 
-        $slug = $this->buildSlug($id, $data['nombre_arrendador'] ?? '');
+        $nombreArrendador    = TextHelper::titleCase((string)($data['nombre_arrendador'] ?? ''));
+        $direccionArrendador = TextHelper::titleCase((string)($data['direccion_arrendador'] ?? ''));
+
+        $slug = $this->buildSlug($id, $nombreArrendador);
 
         $sql = 'UPDATE arrendadores SET
                     nombre_arrendador    = :nombre_arrendador,
@@ -278,10 +282,10 @@ class ArrendadorModel extends Database
                 WHERE id = :id';
 
         $this->execute($sql, [
-            ':nombre_arrendador' => $data['nombre_arrendador'] ?? '',
+            ':nombre_arrendador' => $nombreArrendador,
             ':email'             => $data['email'] ?? '',
             ':celular'           => $data['celular'] ?? '',
-            ':direccion'         => $data['direccion_arrendador'] ?? '',
+            ':direccion'         => $direccionArrendador,
             ':estadocivil'       => $data['estadocivil'] ?? '',
             ':nacionalidad'      => $data['nacionalidad'] ?? '',
             ':rfc'               => $data['rfc'] ?? '',

--- a/Backend/admin/Models/AsesorModel.php
+++ b/Backend/admin/Models/AsesorModel.php
@@ -7,6 +7,7 @@ namespace App\Models;
 require_once __DIR__ . '/../Core/Database.php';
 
 use App\Core\Database;
+use App\Helpers\TextHelper;
 use PDO;
 use RuntimeException;
 
@@ -197,7 +198,7 @@ class AsesorModel extends Database
      */
     public function create(array $data): int
     {
-        $nombre = trim((string) ($data['nombre_asesor'] ?? ''));
+        $nombre = TextHelper::titleCase(trim((string) ($data['nombre_asesor'] ?? '')));
         $email  = mb_strtolower(trim((string) ($data['email'] ?? '')), 'UTF-8');
         $cel    = trim((string) ($data['celular'] ?? ''));
 
@@ -234,7 +235,7 @@ class AsesorModel extends Database
      */
     public function update(int $id, array $data): bool
     {
-        $nombre = trim((string) ($data['nombre_asesor'] ?? ''));
+        $nombre = TextHelper::titleCase(trim((string) ($data['nombre_asesor'] ?? '')));
         $email  = mb_strtolower(trim((string) ($data['email'] ?? '')), 'UTF-8');
         $cel    = trim((string) ($data['celular'] ?? ''));
 

--- a/Backend/admin/Models/InmueblesModel.php
+++ b/Backend/admin/Models/InmueblesModel.php
@@ -7,6 +7,7 @@ namespace App\Models;
 require_once __DIR__ . '/../Core/Database.php';
 
 use App\Core\Database;
+use App\Helpers\TextHelper;
 use InvalidArgumentException;
 use PDO;
 
@@ -347,7 +348,8 @@ class InmuebleModel extends Database
         } else {
             $stmt->bindValue(':id_asesor', null, PDO::PARAM_NULL);
         }
-        $stmt->bindValue(':direccion', (string) $data['direccion_inmueble']);
+        $direccion = TextHelper::titleCase((string) ($data['direccion_inmueble'] ?? ''));
+        $stmt->bindValue(':direccion', $direccion);
         $stmt->bindValue(':tipo', (string) $data['tipo']);
         $stmt->bindValue(':renta', (string) $data['renta']);
         $stmt->bindValue(':mantenimiento', (string) $data['mantenimiento']);
@@ -392,7 +394,8 @@ class InmuebleModel extends Database
         } else {
             $stmt->bindValue(':id_asesor', null, PDO::PARAM_NULL);
         }
-        $stmt->bindValue(':direccion', (string) $data['direccion_inmueble']);
+        $direccion = TextHelper::titleCase((string) ($data['direccion_inmueble'] ?? ''));
+        $stmt->bindValue(':direccion', $direccion);
         $stmt->bindValue(':tipo', (string) $data['tipo']);
         $stmt->bindValue(':renta', (string) $data['renta']);
         $stmt->bindValue(':mantenimiento', (string) $data['mantenimiento']);

--- a/Backend/admin/Models/InquilinoModel.php
+++ b/Backend/admin/Models/InquilinoModel.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/AsesorModel.php';
 
 use App\Core\Database;
 use App\Helpers\S3Helper;
+use App\Helpers\TextHelper;
 use PDO;
 
 class InquilinoModel extends Database
@@ -77,6 +78,23 @@ class InquilinoModel extends Database
             return null;
         }
         return json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<int, string>   $keys
+     *
+     * @return array<string, mixed>
+     */
+    private function applyTitleCase(array $data, array $keys): array
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $data)) {
+                $data[$key] = TextHelper::titleCase((string) $data[$key]);
+            }
+        }
+
+        return $data;
     }
 
     private function decodeJson($value): array
@@ -707,6 +725,13 @@ class InquilinoModel extends Database
             return false;
         }
 
+        $data = $this->applyTitleCase($data, [
+            'nombre_inquilino',
+            'apellidop_inquilino',
+            'apellidom_inquilino',
+            'conyuge',
+        ]);
+
         $campos = [
             'tipo', 'nombre_inquilino', 'apellidop_inquilino', 'apellidom_inquilino',
             'email', 'celular', 'estadocivil', 'nacionalidad', 'curp', 'rfc',
@@ -740,6 +765,7 @@ class InquilinoModel extends Database
 
         $datos = array_intersect_key($domicilio, $this->defaultDireccion());
         $datos = array_map(static fn($v) => (string) $v, $datos);
+        $datos = $this->applyTitleCase($datos, ['calle', 'colonia', 'alcaldia', 'ciudad']);
 
         $stmt = $this->db->prepare('SELECT id FROM inquilinos_direccion WHERE id_inquilino = :id LIMIT 1');
         $stmt->execute([':id' => $id]);
@@ -778,6 +804,7 @@ class InquilinoModel extends Database
 
         $datos = array_intersect_key($trabajo, $this->defaultTrabajo());
         $datos = array_map(static fn($v) => (string) $v, $datos);
+        $datos = $this->applyTitleCase($datos, ['empresa', 'direccion_empresa', 'nombre_jefe']);
 
         $stmt = $this->db->prepare('SELECT id FROM inquilinos_trabajo WHERE id_inquilino = :id LIMIT 1');
         $stmt->execute([':id' => $id]);
@@ -816,6 +843,14 @@ class InquilinoModel extends Database
 
         $datos = array_intersect_key($fiador, $this->defaultFiador());
         $datos = array_map(static fn($v) => (string) $v, $datos);
+        $datos = $this->applyTitleCase($datos, [
+            'calle_inmueble',
+            'colonia_inmueble',
+            'alcaldia_inmueble',
+            'estado_inmueble',
+            'nombre_notario',
+            'estado_notario',
+        ]);
 
         $stmt = $this->db->prepare('SELECT id FROM inquilinos_fiador WHERE id_inquilino = :id LIMIT 1');
         $stmt->execute([':id' => $id]);
@@ -854,6 +889,7 @@ class InquilinoModel extends Database
 
         $datos = array_intersect_key($historial, $this->defaultHistorial());
         $datos = array_map(static fn($v) => (string) $v, $datos);
+        $datos = $this->applyTitleCase($datos, ['arrendador_actual']);
 
         $stmt = $this->db->prepare('SELECT id FROM inquilinos_historial_vivienda WHERE id_inquilino = :id LIMIT 1');
         $stmt->execute([':id' => $id]);

--- a/Backend/admin/Models/PolizaModel.php
+++ b/Backend/admin/Models/PolizaModel.php
@@ -4,8 +4,9 @@ namespace App\Models;
 
 require_once __DIR__ . '/../Core/Database.php';
 
-use App\Helpers\NormalizadoHelper;
 use App\Core\Database;
+use App\Helpers\NormalizadoHelper;
+use App\Helpers\TextHelper;
 use PDO;
 
 /**
@@ -657,7 +658,11 @@ class PolizaModel extends Database
         foreach ($permitidos as $campo) {
             if (array_key_exists($campo, $data)) {
                 $campos[] = "$campo = :$campo";
-                $params[":$campo"] = $data[$campo];
+                $valor = $data[$campo];
+                if ($campo === 'direccion_inmueble') {
+                    $valor = TextHelper::titleCase((string) $valor);
+                }
+                $params[":$campo"] = $valor;
             }
         }
 
@@ -684,7 +689,11 @@ class PolizaModel extends Database
         foreach ($permitidos as $campo) {
             if (array_key_exists($campo, $data)) {
                 $campos[] = "$campo = :$campo";
-                $params[":$campo"] = $data[$campo];
+                $valor = $data[$campo];
+                if ($campo === 'direccion_inmueble') {
+                    $valor = TextHelper::titleCase((string) $valor);
+                }
+                $params[":$campo"] = $valor;
             }
         }
 
@@ -778,10 +787,11 @@ class PolizaModel extends Database
         $ok = $this->update($numero, $data);
 
         if ($ok && isset($data['direccion'])) {
+            $direccion = TextHelper::titleCase((string) $data['direccion']);
             $poliza = $this->obtenerPorNumero($numero);
             if ($poliza && !empty($poliza['id_inmueble'])) {
                 $this->updateInmueble((int)$poliza['id_inmueble'], [
-                    'direccion_inmueble' => $data['direccion']
+                    'direccion_inmueble' => $direccion
                 ]);
             }
         }

--- a/Backend/admin/Models/UserModel.php
+++ b/Backend/admin/Models/UserModel.php
@@ -7,6 +7,7 @@ namespace App\Models;
 require_once __DIR__ . '/../Core/Database.php';
 
 use App\Core\Database;
+use App\Helpers\TextHelper;
 use PDO;
 use RuntimeException;
 
@@ -88,10 +89,10 @@ class UserModel extends Database
 
         $stmt = $this->db->prepare($sql);
         $stmt->execute([
-            ':nombre'    => (string)($data['nombre_usuario'] ?? ''),
-            ':apellidos' => (string)($data['apellidos_usuario'] ?? ''),
+            ':nombre'    => TextHelper::titleCase((string)($data['nombre_usuario'] ?? '')),
+            ':apellidos' => TextHelper::titleCase((string)($data['apellidos_usuario'] ?? '')),
             ':usuario'   => $username,
-            ':corto'     => (string)($data['corto_usuario'] ?? ''),
+            ':corto'     => TextHelper::titleCase((string)($data['corto_usuario'] ?? '')),
             ':mail'      => $email,
             ':password'  => $password,
             ':tipo'      => (int)($data['tipo_usuario'] ?? 0),


### PR DESCRIPTION
## Summary
- ensure arrendador, asesor, inmueble and user models title-case names and addresses before database writes
- add reusable helper in InquilinoModel to title-case personal, address, fiador and historial fields prior to updates or inserts
- normalize inmueble updates from PolizaModel to store directions in title case when syncing related records

## Testing
- php -l admin/Models/ArrendadorModel.php
- php -l admin/Models/AsesorModel.php
- php -l admin/Models/InquilinoModel.php
- php -l admin/Models/InmueblesModel.php
- php -l admin/Models/PolizaModel.php
- php -l admin/Models/UserModel.php

------
https://chatgpt.com/codex/tasks/task_e_68d3155f80388323a2d81b3a91fd7a26