### PR TITLE
Ensure TextHelper helper is loaded in models

### DIFF
--- a/Backend/admin/Models/ArrendadorModel.php
+++ b/Backend/admin/Models/ArrendadorModel.php
@@ -7,10 +7,12 @@ namespace App\Models;
 require_once __DIR__ . '/../Core/Database.php';
 require_once __DIR__ . '/../Helpers/NormalizadoHelper.php';
 require_once __DIR__ . '/../Helpers/SlugHelper.php';
+require_once __DIR__ . '/../Helpers/TextHelper.php';
 
 use App\Core\Database;
 use App\Helpers\NormalizadoHelper;
 use App\Helpers\SlugHelper;
+use App\Helpers\TextHelper;
 use RuntimeException;
 
 class ArrendadorModel extends Database
@@ -262,7 +264,10 @@ class ArrendadorModel extends Database
 
         $id = (int)$matches[1];
 
-        $slug = $this->buildSlug($id, $data['nombre_arrendador'] ?? '');
+        $nombreArrendador    = TextHelper::titleCase((string)($data['nombre_arrendador'] ?? ''));
+        $direccionArrendador = TextHelper::titleCase((string)($data['direccion_arrendador'] ?? ''));
+
+        $slug = $this->buildSlug($id, $nombreArrendador);
 
         $sql = 'UPDATE arrendadores SET
                     nombre_arrendador    = :nombre_arrendador,
@@ -278,10 +283,10 @@ class ArrendadorModel extends Database
                 WHERE id = :id';
 
         $this->execute($sql, [
-            ':nombre_arrendador' => $data['nombre_arrendador'] ?? '',
+            ':nombre_arrendador' => $nombreArrendador,
             ':email'             => $data['email'] ?? '',
             ':celular'           => $data['celular'] ?? '',
-            ':direccion'         => $data['direccion_arrendador'] ?? '',
+            ':direccion'         => $direccionArrendador,
             ':estadocivil'       => $data['estadocivil'] ?? '',
             ':nacionalidad'      => $data['nacionalidad'] ?? '',
             ':rfc'               => $data['rfc'] ?? '',

--- a/Backend/admin/Models/AsesorModel.php
+++ b/Backend/admin/Models/AsesorModel.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Models;
 
 require_once __DIR__ . '/../Core/Database.php';
+require_once __DIR__ . '/../Helpers/TextHelper.php';
 
 use App\Core\Database;
+use App\Helpers\TextHelper;
 use PDO;
 use RuntimeException;
 
@@ -197,7 +199,7 @@ class AsesorModel extends Database
      */
     public function create(array $data): int
     {
-        $nombre = trim((string) ($data['nombre_asesor'] ?? ''));
+        $nombre = TextHelper::titleCase(trim((string) ($data['nombre_asesor'] ?? '')));
         $email  = mb_strtolower(trim((string) ($data['email'] ?? '')), 'UTF-8');
         $cel    = trim((string) ($data['celular'] ?? ''));
 
@@ -234,7 +236,7 @@ class AsesorModel extends Database
      */
     public function update(int $id, array $data): bool
     {
-        $nombre = trim((string) ($data['nombre_asesor'] ?? ''));
+        $nombre = TextHelper::titleCase(trim((string) ($data['nombre_asesor'] ?? '')));
         $email  = mb_strtolower(trim((string) ($data['email'] ?? '')), 'UTF-8');
         $cel    = trim((string) ($data['celular'] ?? ''));
 

--- a/Backend/admin/Models/InmueblesModel.php
+++ b/Backend/admin/Models/InmueblesModel.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Models;
 
 require_once __DIR__ . '/../Core/Database.php';
+require_once __DIR__ . '/../Helpers/TextHelper.php';
 
 use App\Core\Database;
+use App\Helpers\TextHelper;
 use InvalidArgumentException;
 use PDO;
 
@@ -347,7 +349,8 @@ class InmuebleModel extends Database
         } else {
             $stmt->bindValue(':id_asesor', null, PDO::PARAM_NULL);
         }
-        $stmt->bindValue(':direccion', (string) $data['direccion_inmueble']);
+        $direccion = TextHelper::titleCase((string) ($data['direccion_inmueble'] ?? ''));
+        $stmt->bindValue(':direccion', $direccion);
         $stmt->bindValue(':tipo', (string) $data['tipo']);
         $stmt->bindValue(':renta', (string) $data['renta']);
         $stmt->bindValue(':mantenimiento', (string) $data['mantenimiento']);
@@ -392,7 +395,8 @@ class InmuebleModel extends Database
         } else {
             $stmt->bindValue(':id_asesor', null, PDO::PARAM_NULL);
         }
-        $stmt->bindValue(':direccion', (string) $data['direccion_inmueble']);
+        $direccion = TextHelper::titleCase((string) ($data['direccion_inmueble'] ?? ''));
+        $stmt->bindValue(':direccion', $direccion);
         $stmt->bindValue(':tipo', (string) $data['tipo']);
         $stmt->bindValue(':renta', (string) $data['renta']);
         $stmt->bindValue(':mantenimiento', (string) $data['mantenimiento']);

--- a/Backend/admin/Models/PolizaModel.php
+++ b/Backend/admin/Models/PolizaModel.php
@@ -3,9 +3,11 @@
 namespace App\Models;
 
 require_once __DIR__ . '/../Core/Database.php';
+require_once __DIR__ . '/../Helpers/TextHelper.php';
 
-use App\Helpers\NormalizadoHelper;
 use App\Core\Database;
+use App\Helpers\NormalizadoHelper;
+use App\Helpers\TextHelper;
 use PDO;
 
 /**
@@ -657,7 +659,11 @@ class PolizaModel extends Database
         foreach ($permitidos as $campo) {
             if (array_key_exists($campo, $data)) {
                 $campos[] = "$campo = :$campo";
-                $params[":$campo"] = $data[$campo];
+                $valor = $data[$campo];
+                if ($campo === 'direccion_inmueble') {
+                    $valor = TextHelper::titleCase((string) $valor);
+                }
+                $params[":$campo"] = $valor;
             }
         }
 
@@ -684,7 +690,11 @@ class PolizaModel extends Database
         foreach ($permitidos as $campo) {
             if (array_key_exists($campo, $data)) {
                 $campos[] = "$campo = :$campo";
-                $params[":$campo"] = $data[$campo];
+                $valor = $data[$campo];
+                if ($campo === 'direccion_inmueble') {
+                    $valor = TextHelper::titleCase((string) $valor);
+                }
+                $params[":$campo"] = $valor;
             }
         }
 
@@ -778,10 +788,11 @@ class PolizaModel extends Database
         $ok = $this->update($numero, $data);
 
         if ($ok && isset($data['direccion'])) {
+            $direccion = TextHelper::titleCase((string) $data['direccion']);
             $poliza = $this->obtenerPorNumero($numero);
             if ($poliza && !empty($poliza['id_inmueble'])) {
                 $this->updateInmueble((int)$poliza['id_inmueble'], [
-                    'direccion_inmueble' => $data['direccion']
+                    'direccion_inmueble' => $direccion
                 ]);
             }
         }

--- a/Backend/admin/Models/UserModel.php
+++ b/Backend/admin/Models/UserModel.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Models;
 
 require_once __DIR__ . '/../Core/Database.php';
+require_once __DIR__ . '/../Helpers/TextHelper.php';
 
 use App\Core\Database;
+use App\Helpers\TextHelper;
 use PDO;
 use RuntimeException;
 
@@ -88,10 +90,10 @@ class UserModel extends Database
 
         $stmt = $this->db->prepare($sql);
         $stmt->execute([
-            ':nombre'    => (string)($data['nombre_usuario'] ?? ''),
-            ':apellidos' => (string)($data['apellidos_usuario'] ?? ''),
+            ':nombre'    => TextHelper::titleCase((string)($data['nombre_usuario'] ?? '')),
+            ':apellidos' => TextHelper::titleCase((string)($data['apellidos_usuario'] ?? '')),
             ':usuario'   => $username,
-            ':corto'     => (string)($data['corto_usuario'] ?? ''),
+            ':corto'     => TextHelper::titleCase((string)($data['corto_usuario'] ?? '')),
             ':mail'      => $email,
             ':password'  => $password,
             ':tipo'      => (int)($data['tipo_usuario'] ?? 0),


### PR DESCRIPTION
## Summary
- include the TextHelper helper file before using it in each model that formats data in title case

## Testing
- php -l Backend/admin/Models/ArrendadorModel.php
- php -l Backend/admin/Models/AsesorModel.php
- php -l Backend/admin/Models/InmueblesModel.php
- php -l Backend/admin/Models/InquilinoModel.php
- php -l Backend/admin/Models/PolizaModel.php
- php -l Backend/admin/Models/UserModel.php

------
https://chatgpt.com/codex/tasks/task_e_68d3155f80388323a2d81b3a91fd7a26