### PR TITLE
Agregar eliminación de prospectos desde el detalle de inquilino

### DIFF
--- a/Backend/admin/Controllers/InquilinoController.php
+++ b/Backend/admin/Controllers/InquilinoController.php
@@ -17,6 +17,7 @@ use App\Helpers\SlugHelper;
 use App\Middleware\AuthMiddleware;
 use App\Models\AsesorModel;
 use App\Models\InquilinoModel;
+use RuntimeException;
 
 class InquilinoController
 {
@@ -719,6 +720,36 @@ class InquilinoController
         } catch (\Throwable $e) {
             http_response_code(500);
             echo json_encode(['ok' => false, 'error' => $e->getMessage()]);
+        }
+    }
+
+    public function eliminar(): void
+    {
+        header('Content-Type: application/json; charset=utf-8');
+
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['ok' => false, 'error' => 'Metodo no permitido']);
+            return;
+        }
+
+        $idInquilino = (int)($_POST['id'] ?? $_POST['id_inquilino'] ?? 0);
+
+        if ($idInquilino <= 0) {
+            http_response_code(400);
+            echo json_encode(['ok' => false, 'error' => 'ID de inquilino inválido']);
+            return;
+        }
+
+        try {
+            $this->model->eliminarInquilino($idInquilino);
+            echo json_encode(['ok' => true]);
+        } catch (RuntimeException $e) {
+            http_response_code(400);
+            echo json_encode(['ok' => false, 'error' => $e->getMessage()]);
+        } catch (\Throwable $e) {
+            http_response_code(500);
+            echo json_encode(['ok' => false, 'error' => 'No se pudo eliminar al inquilino']);
         }
     }
 

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -531,6 +531,12 @@ switch (true) {
         exit;
         break;
 
+    case $uri === '/inquilino/eliminar' && $_SERVER['REQUEST_METHOD'] === 'POST':
+        require __DIR__ . '/Controllers/InquilinoController.php';
+        (new \App\Controllers\InquilinoController())->eliminar();
+        exit;
+        break;
+
     case $uri === '/inquilino/editar-validaciones' && $_SERVER['REQUEST_METHOD'] === 'POST':
         require __DIR__ . '/Controllers/InquilinoController.php';
         (new \App\Controllers\InquilinoController())->editarValidaciones();


### PR DESCRIPTION
## Summary
- agrega un botón de eliminación en la vista de detalle del inquilino con confirmación y feedback
- crea el endpoint en el router y controlador para borrar al prospecto y sus archivos de S3
- implementa en el modelo la eliminación transaccional de datos relacionados y valida que no existan pólizas ligadas

## Testing
- php -l Backend/admin/router.php
- php -l Backend/admin/Controllers/InquilinoController.php
- php -l Backend/admin/Models/InquilinoModel.php
- php -l Backend/admin/Views/inquilino/detalle.php

------
https://chatgpt.com/codex/tasks/task_e_68d331c6b70883238ca5cd49ba5da0b4