### PR TITLE
Fix VerificaMex visibility and detail hydration

### DIFF
--- a/Backend/admin/assets/validaciones-core.js
+++ b/Backend/admin/assets/validaciones-core.js
@@ -185,8 +185,29 @@ async function loadStatus() {
 	setText("#vh-ts", `Última actualización ${ts}`);
 	setText("#vh-ts-bottom", `Última actualización ${ts}`);
 
-	// Guardamos detalles globales
-	window.__VH_DETALLES__ = j.detalles || j;
+        // Guardamos detalles globales fusionando con lo previamente cargado
+        const incomingDetalles = (() => {
+                if (j && typeof j === "object" && j.detalles && typeof j.detalles === "object") {
+                        return j.detalles;
+                }
+                return j && typeof j === "object" ? j : {};
+        })();
+
+        const prevDetalles =
+                window.__VH_DETALLES__ && typeof window.__VH_DETALLES__ === "object"
+                        ? window.__VH_DETALLES__
+                        : {};
+
+        const mergedDetalles = { ...prevDetalles };
+        Object.entries(incomingDetalles || {}).forEach(([clave, valor]) => {
+                if (valor !== undefined && valor !== null) {
+                        mergedDetalles[clave] = valor;
+                } else if (!(clave in mergedDetalles)) {
+                        mergedDetalles[clave] = valor;
+                }
+        });
+
+        window.__VH_DETALLES__ = mergedDetalles;
 
 	// 🔎 Normalizamos identidad
 	const identidadInfo = j.detalles?.identidad || {};


### PR DESCRIPTION
## Summary
- Relax VerificaMex detection in the status controller so stored data is returned even if tipo_id formatting changes
- Show the saved VerificaMex summary and preload its details from PHP while reusing the relaxed visibility flag in the view
- Merge AJAX payloads into the existing detail cache to avoid losing VerificaMex data on partial responses

## Testing
- php -l Backend/admin/Views/inquilino/validaciones.php
- php -l Backend/admin/Controllers/InquilinoValidacionAWSController.php

------
https://chatgpt.com/codex/tasks/task_e_68d3802c844c83238d0b00f8f23051f8