### PR TITLE
Normaliza y ordena fechas en vencimientos

### DIFF
--- a/Backend/admin/Controllers/VencimientosController.php
+++ b/Backend/admin/Controllers/VencimientosController.php
@@ -1,12 +1,19 @@
 <?php
+
 namespace App\Controllers;
+
 require_once __DIR__ . '/../Middleware/AuthMiddleware.php';
+
 use App\Middleware\AuthMiddleware;
+
 AuthMiddleware::verificarSesion();
 
 require_once __DIR__ . '/../Models/PolizaModel.php';
 
 use App\Models\PolizaModel;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Throwable;
 
 class VencimientosController
 {
@@ -32,6 +39,38 @@ class VencimientosController
             }
         }
 
+        $polizas = array_map(function (array $poliza): array {
+            $fechaNormalizada = $this->normalizarFechaVencimiento($poliza);
+            $poliza['fecha_vencimiento_normalizada'] = $fechaNormalizada;
+            $poliza['fecha_vencimiento_formateada'] = $fechaNormalizada instanceof DateTimeImmutable
+                ? $fechaNormalizada->format('d/m/Y')
+                : null;
+
+            return $poliza;
+        }, $polizas);
+
+        usort(
+            $polizas,
+            function (array $a, array $b): int {
+                $fechaA = $a['fecha_vencimiento_normalizada'] ?? null;
+                $fechaB = $b['fecha_vencimiento_normalizada'] ?? null;
+
+                if (!$fechaA instanceof DateTimeInterface && !$fechaB instanceof DateTimeInterface) {
+                    return 0;
+                }
+
+                if (!$fechaA instanceof DateTimeInterface) {
+                    return 1;
+                }
+
+                if (!$fechaB instanceof DateTimeInterface) {
+                    return -1;
+                }
+
+                return $fechaA->getTimestamp() <=> $fechaB->getTimestamp();
+            }
+        );
+
         $mesSeleccionado  = $mes;
         $anioSeleccionado = $anio;
 
@@ -39,5 +78,72 @@ class VencimientosController
         $headerTitle = 'Vencimientos próximos';
         $contentView = __DIR__ . '/../Views/vencimientos/index.php';
         include __DIR__ . '/../Views/layouts/main.php';
+    }
+
+    private function normalizarFechaVencimiento(array $poliza): ?DateTimeImmutable
+    {
+        $fechaFin = $poliza['fecha_fin'] ?? null;
+
+        if (!empty($fechaFin)) {
+            try {
+                return (new DateTimeImmutable((string) $fechaFin))->setTime(0, 0);
+            } catch (Throwable $exception) {
+                // Continuar con las demás opciones de normalización
+            }
+        }
+
+        $vigencia = $poliza['vigencia'] ?? null;
+
+        if (is_string($vigencia)) {
+            $patron = '/al\s+(\d{1,2})\s+de\s+([[:alpha:]]+)\s+de\s+(\d{4})/iu';
+
+            if (preg_match($patron, $vigencia, $coincidencias)) {
+                $dia       = (int) $coincidencias[1];
+                $mesNombre = mb_strtolower($coincidencias[2], 'UTF-8');
+                $anio      = (int) $coincidencias[3];
+
+                $meses = [
+                    'enero'      => 1,
+                    'febrero'    => 2,
+                    'marzo'      => 3,
+                    'abril'      => 4,
+                    'mayo'       => 5,
+                    'junio'      => 6,
+                    'julio'      => 7,
+                    'agosto'     => 8,
+                    'septiembre' => 9,
+                    'setiembre'  => 9,
+                    'octubre'    => 10,
+                    'noviembre'  => 11,
+                    'diciembre'  => 12,
+                ];
+
+                if (array_key_exists($mesNombre, $meses)) {
+                    $fecha = sprintf('%04d-%02d-%02d', $anio, $meses[$mesNombre], $dia);
+
+                    try {
+                        return (new DateTimeImmutable($fecha))->setTime(0, 0);
+                    } catch (Throwable $exception) {
+                        // Continuar con las demás opciones de normalización
+                    }
+                }
+            }
+        }
+
+        $mes  = $poliza['mes_vencimiento'] ?? null;
+        $anio = $poliza['year_vencimiento'] ?? null;
+
+        if ($mes !== null && $anio !== null) {
+            $mesFormateado   = str_pad((string) $mes, 2, '0', STR_PAD_LEFT);
+            $fechaConstruida = sprintf('%s-%s-01', (string) $anio, $mesFormateado);
+
+            try {
+                return (new DateTimeImmutable($fechaConstruida))->setTime(0, 0);
+            } catch (Throwable $exception) {
+                return null;
+            }
+        }
+
+        return null;
     }
 }

--- a/Backend/admin/Views/vencimientos/index.php
+++ b/Backend/admin/Views/vencimientos/index.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../../Helpers/TextHelper.php';
 
 use App\Helpers\TextHelper;
+use DateTimeImmutable;
 
 
 /**
@@ -187,8 +188,6 @@ $tituloAnio = (int)($anioSeleccionado ?? date('Y'));
             $vigencia = TextHelper::titleCase($poliza['vigencia'] ?? '');
             $estado   = $poliza['estado'] ?? '';
 
-            $venceMes  = str_pad((string)($poliza['mes_vencimiento'] ?? ''), 2, '0', STR_PAD_LEFT);
-            $venceAnio = htmlspecialchars($poliza['year_vencimiento'] ?? '');
             $renta     = money_mx($poliza['monto_renta'] ?? 0, 0);
             $mpoliza   = money_mx($poliza['monto_poliza'] ?? 0, 2);
 
@@ -199,6 +198,17 @@ $tituloAnio = (int)($anioSeleccionado ?? date('Y'));
             $asesor     = TextHelper::titleCase($poliza['nombre_asesor'] ?? '');
             $direccion  = TextHelper::titleCase($poliza['direccion'] ?? '');
             $tipoInm    = TextHelper::titleCase($poliza['tipo_inmueble'] ?? '');
+
+            $fechaVencimiento = $poliza['fecha_vencimiento_normalizada'] ?? null;
+            $venceTexto       = $poliza['fecha_vencimiento_formateada'] ?? null;
+
+            if ($fechaVencimiento instanceof DateTimeImmutable) {
+                $venceTexto = $fechaVencimiento->format('d/m/Y');
+            }
+
+            if (!is_string($venceTexto) || $venceTexto === '') {
+                $venceTexto = 'Sin fecha';
+            }
             ?>
 
             <article class="relative w-full max-w-2xl mx-auto bg-gradient-to-br from-indigo-950/80 to-gray-900/90 rounded-3xl shadow-2xl border border-indigo-900/70 p-5 md:p-7 overflow-hidden group transition-all hover:scale-[1.012]">
@@ -237,7 +247,7 @@ $tituloAnio = (int)($anioSeleccionado ?? date('Y'));
                 <!-- Fechas y montos -->
                 <section class="relative z-10 mt-6 flex flex-wrap items-center gap-3">
                     <span class="bg-pink-500 text-white px-4 py-1 rounded-full text-sm font-bold tracking-wide shadow group-hover:bg-pink-600 transition">
-                        Vence: <?= $venceMes ?>/<?= $venceAnio ?>
+                        Vence: <?= htmlspecialchars($venceTexto) ?>
                     </span>
                     <span class="bg-gray-800 text-pink-200 px-4 py-1 rounded-full text-sm font-semibold">
                         Renta: $<?= $renta ?>


### PR DESCRIPTION
## Summary
- normaliza las fechas de vencimiento de las pólizas en el controlador replicando la lógica del dashboard
- ordena las pólizas por fecha normalizada y expone la representación formateada para la vista
- ajusta la vista de vencimientos para mostrar la fecha normalizada en lugar del mes/año manual

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd8ea057d08323addbf66dca379502