### PR TITLE
Remove redundant DateTimeImmutable import from vencimientos view

### DIFF
--- a/Backend/admin/Views/vencimientos/index.php
+++ b/Backend/admin/Views/vencimientos/index.php
@@ -2,9 +2,6 @@
 require_once __DIR__ . '/../../Helpers/TextHelper.php';
 
 use App\Helpers\TextHelper;
-use DateTimeImmutable;
-
-
 /**
  * Vista: Vencimientos / index.php
  * ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove an unused DateTimeImmutable import from the vencimientos view to eliminate runtime warnings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dda1a825988323b1fb59b05e500b4f