### PR TITLE
Add API client management UI and token flow

### DIFF
--- a/Backend/admin/Controllers/Api/AuthApiController.php
+++ b/Backend/admin/Controllers/Api/AuthApiController.php
@@ -4,66 +4,99 @@ declare(strict_types=1);
 
 namespace App\Controllers\Api;
 
-require_once __DIR__ . '/../../Models/UserModel.php';
 require_once __DIR__ . '/../../Helpers/JwtHelper.php';
+require_once __DIR__ . '/../../Helpers/ApiScopeHelper.php';
+require_once __DIR__ . '/../../Helpers/ApiAuthConfig.php';
+require_once __DIR__ . '/../../Models/ApiClientModel.php';
+require_once __DIR__ . '/../../Models/ApiRefreshTokenModel.php';
+require_once __DIR__ . '/../../Models/ApiTokenRevocationModel.php';
 
+use App\Helpers\ApiAuthConfig;
+use App\Helpers\ApiScopeHelper;
 use App\Helpers\JwtHelper;
-use App\Models\UserModel;
+use App\Models\ApiClientModel;
+use App\Models\ApiRefreshTokenModel;
+use App\Models\ApiTokenRevocationModel;
+use DateInterval;
+use DateTimeImmutable;
 use Throwable;
 
 class AuthApiController
 {
-    private const REFRESH_WINDOW_SECONDS = 900;
+    private ApiClientModel $clientModel;
 
-    private UserModel $userModel;
+    private ApiRefreshTokenModel $refreshTokenModel;
 
-    private int $tokenTtl;
+    private ApiTokenRevocationModel $revocationModel;
 
-    public function __construct(?UserModel $userModel = null, int $tokenTtl = 3600)
-    {
-        $this->userModel = $userModel ?? new UserModel();
-        $this->tokenTtl  = max(1, $tokenTtl);
+    private int $accessTokenTtl;
+
+    private int $refreshTokenTtl;
+
+    private string $expectedAudience;
+
+    public function __construct(
+        ?ApiClientModel $clientModel = null,
+        ?ApiRefreshTokenModel $refreshTokenModel = null,
+        ?ApiTokenRevocationModel $revocationModel = null,
+        ?int $accessTokenTtl = null,
+        ?int $refreshTokenTtl = null,
+        ?string $expectedAudience = null
+    ) {
+        $this->clientModel       = $clientModel ?? new ApiClientModel();
+        $this->refreshTokenModel = $refreshTokenModel ?? new ApiRefreshTokenModel();
+        $this->revocationModel   = $revocationModel ?? new ApiTokenRevocationModel();
+        $this->accessTokenTtl    = $accessTokenTtl ?? ApiAuthConfig::accessTokenTtl();
+        $this->refreshTokenTtl   = $refreshTokenTtl ?? ApiAuthConfig::refreshTokenTtl();
+        $this->expectedAudience  = $expectedAudience ?? ApiAuthConfig::expectedAudience();
     }
 
     public function loginApi(): void
     {
         try {
             $data = $this->readJsonInput();
-
             if ($data === null) {
                 $this->jsonResponse(['error' => 'invalid_request'], 400);
                 return;
             }
 
-            $user     = trim((string)($data['user'] ?? ''));
-            $password = (string)($data['password'] ?? '');
+            $clientId     = trim((string)($data['client_id'] ?? ''));
+            $clientSecret = (string)($data['client_secret'] ?? '');
+            $audience     = trim((string)($data['audience'] ?? ''));
+            $scopes       = isset($data['scopes']) && is_array($data['scopes']) ? $data['scopes'] : [];
 
-            if ($user === '' || $password === '' || !is_string($data['user']) || !is_string($data['password'])) {
+            if ($clientId === '' || $clientSecret === '' || $audience === '') {
                 $this->jsonResponse(['error' => 'invalid_request'], 400);
                 return;
             }
 
-            $record = $this->userModel->findByUser($user);
-            if (!$record || empty($record['password']) || !password_verify($password, (string)$record['password'])) {
-                $this->jsonResponse(['error' => 'invalid_credentials'], 401);
+            if ($audience !== $this->expectedAudience) {
+                $this->jsonResponse(['error' => 'invalid_audience'], 400);
                 return;
             }
 
-            $scope = 'admin:' . (string)($record['tipo_usuario'] ?? '');
+            $client = $this->clientModel->findByClientId($clientId);
+            if ($client === null || ($client['status'] ?? '') !== ApiClientModel::STATUS_ACTIVE) {
+                $this->jsonResponse(['error' => 'invalid_client'], 401);
+                return;
+            }
 
-            $claims = [
-                'sub'   => (string)($record['id'] ?? ''),
-                'scope' => $scope,
-                'exp'   => time() + $this->tokenTtl,
-            ];
+            if (empty($client['secret_hash']) || !password_verify($clientSecret, (string)$client['secret_hash'])) {
+                $this->jsonResponse(['error' => 'invalid_client'], 401);
+                return;
+            }
 
-            $token = JwtHelper::encode($claims, $this->tokenTtl);
+            $allowedScopes   = is_array($client['allowed_scopes']) ? $client['allowed_scopes'] : [];
+            $effectiveScopes = $this->resolveScopes($scopes, $allowedScopes);
+            if ($effectiveScopes === []) {
+                $this->jsonResponse(['error' => 'invalid_scope'], 400);
+                return;
+            }
 
-            $this->jsonResponse([
-                'access_token' => $token,
-                'expires_in'   => $this->tokenTtl,
-                'scope'        => $scope,
-            ]);
+            $payload = $this->issueTokenPair($client, $effectiveScopes, $audience);
+            $this->clientModel->touchLastUsed((int)$client['id']);
+
+            $this->jsonResponse($payload);
         } catch (Throwable $exception) {
             $this->jsonResponse(['error' => 'server_error'], 500);
         }
@@ -72,50 +105,80 @@ class AuthApiController
     public function refreshToken(): void
     {
         try {
-            $token = $this->extractTokenFromRequest();
-            if ($token === null) {
+            $authHeader = $this->getAuthorizationHeader();
+            if ($authHeader === null || stripos($authHeader, 'Bearer ') !== 0) {
+                $this->jsonResponse(['error' => 'missing_access_token'], 401);
+                return;
+            }
+
+            $data = $this->readJsonInput();
+            if (!is_array($data)) {
+                $this->jsonResponse(['error' => 'invalid_request'], 400);
+                return;
+            }
+
+            $refreshToken = trim((string)($data['refresh_token'] ?? ''));
+            if ($refreshToken === '') {
                 $this->jsonResponse(['error' => 'invalid_request'], 400);
                 return;
             }
 
             try {
-                $decoded = JwtHelper::decode($token);
+                $claims = (array)JwtHelper::decode($refreshToken);
             } catch (Throwable $exception) {
                 $this->jsonResponse(['error' => 'invalid_token'], 401);
                 return;
             }
 
-            $claims = (array)$decoded;
-            $now    = time();
-            $exp    = isset($claims['exp']) ? (int)$claims['exp'] : 0;
-
-            if ($exp <= $now) {
-                $this->jsonResponse(['error' => 'token_expired'], 401);
-                return;
-            }
-
-            $remainingLifetime = $exp - $now;
-            if ($remainingLifetime > self::REFRESH_WINDOW_SECONDS) {
-                $this->jsonResponse(['error' => 'refresh_not_required'], 400);
-                return;
-            }
-
-            if (empty($claims['sub']) || empty($claims['scope'])) {
+            if (($claims['type'] ?? '') !== 'refresh') {
                 $this->jsonResponse(['error' => 'invalid_token'], 401);
                 return;
             }
 
-            $newClaims = $claims;
-            unset($newClaims['exp'], $newClaims['iat'], $newClaims['nbf']);
+            $refreshJti = (string)($claims['jti'] ?? '');
+            if ($refreshJti === '') {
+                $this->jsonResponse(['error' => 'invalid_token'], 401);
+                return;
+            }
 
-            $token = JwtHelper::encode($newClaims, $this->tokenTtl);
-            $scope = (string)$claims['scope'];
+            if ($this->revocationModel->isRevoked($refreshJti)) {
+                $this->jsonResponse(['error' => 'token_revoked'], 401);
+                return;
+            }
 
-            $this->jsonResponse([
-                'access_token' => $token,
-                'expires_in'   => $this->tokenTtl,
-                'scope'        => $scope,
-            ]);
+            $stored = $this->refreshTokenModel->findActiveByJti($refreshJti);
+            if ($stored === null) {
+                $this->jsonResponse(['error' => 'invalid_token'], 401);
+                return;
+            }
+
+            $hash = $this->hashToken($refreshToken);
+            if (!hash_equals((string)$stored['refresh_token_hash'], $hash)) {
+                $this->jsonResponse(['error' => 'invalid_token'], 401);
+                return;
+            }
+
+            $clientId = (int)($stored['client_id'] ?? 0);
+            $client   = $clientId > 0 ? $this->clientModel->findById($clientId) : null;
+            if ($client === null || ($client['status'] ?? '') !== ApiClientModel::STATUS_ACTIVE) {
+                $this->jsonResponse(['error' => 'invalid_client'], 401);
+                return;
+            }
+
+            $storedScopes = $this->refreshTokenModel->extractScopes($stored);
+            $effective    = $this->resolveScopes($storedScopes, $client['allowed_scopes'] ?? []);
+            if ($effective === []) {
+                $this->jsonResponse(['error' => 'invalid_scope'], 400);
+                return;
+            }
+
+            $this->refreshTokenModel->markConsumed((int)$stored['id']);
+
+            $audience = (string)($claims['aud'] ?? $this->expectedAudience);
+            $payload  = $this->issueTokenPair($client, $effective, $audience);
+            $this->clientModel->touchLastUsed((int)$client['id']);
+
+            $this->jsonResponse($payload);
         } catch (Throwable $exception) {
             $this->jsonResponse(['error' => 'server_error'], 500);
         }
@@ -124,7 +187,7 @@ class AuthApiController
     private function readJsonInput(): ?array
     {
         $input = file_get_contents('php://input');
-        if ($input === false || $input === '') {
+        if ($input === false || trim($input) === '') {
             return null;
         }
 
@@ -134,41 +197,6 @@ class AuthApiController
         }
 
         return $decoded;
-    }
-
-    private function extractTokenFromRequest(): ?string
-    {
-        $token = $this->getBearerTokenFromHeaders();
-        if ($token !== null) {
-            return $token;
-        }
-
-        $data = $this->readJsonInput();
-        if (!is_array($data)) {
-            return null;
-        }
-
-        $bodyToken = $data['token'] ?? $data['access_token'] ?? null;
-        if (!is_string($bodyToken) || trim($bodyToken) === '') {
-            return null;
-        }
-
-        return trim($bodyToken);
-    }
-
-    private function getBearerTokenFromHeaders(): ?string
-    {
-        $header = $this->getAuthorizationHeader();
-        if ($header === null) {
-            return null;
-        }
-
-        if (stripos($header, 'Bearer ') !== 0) {
-            return null;
-        }
-
-        $token = trim(substr($header, 7));
-        return $token === '' ? null : $token;
     }
 
     private function getAuthorizationHeader(): ?string
@@ -197,5 +225,96 @@ class AuthApiController
         http_response_code($statusCode);
         header('Content-Type: application/json');
         echo json_encode($data);
+    }
+
+    /**
+     * @param array<int, string> $requested
+     * @param array<int, string> $allowed
+     * @return array<int, string>
+     */
+    private function resolveScopes(array $requested, array $allowed): array
+    {
+        $allowed = ApiScopeHelper::filter($allowed);
+        if ($allowed === []) {
+            return [];
+        }
+
+        if ($requested === []) {
+            return $allowed;
+        }
+
+        $requested = ApiScopeHelper::filter($requested);
+        $scopes    = array_values(array_intersect($requested, $allowed));
+
+        return $scopes === [] ? $allowed : $scopes;
+    }
+
+    /**
+     * @param array<string, mixed> $client
+     * @param array<int, string> $scopes
+     */
+    private function issueTokenPair(array $client, array $scopes, string $audience): array
+    {
+        $scopeString = implode(' ', $scopes);
+        $accessJti   = $this->uuid();
+        $refreshJti  = $this->uuid();
+        $subject     = 'client:' . (string)$client['client_id'];
+
+        $accessClaims = [
+            'sub'   => $subject,
+            'cid'   => (int)$client['id'],
+            'scope' => $scopeString,
+            'aud'   => $audience,
+            'jti'   => $accessJti,
+            'type'  => 'access',
+        ];
+
+        $accessToken = JwtHelper::encode($accessClaims, $this->accessTokenTtl);
+
+        $refreshClaims = [
+            'sub'   => $subject,
+            'cid'   => (int)$client['id'],
+            'scope' => $scopeString,
+            'aud'   => $audience,
+            'jti'   => $refreshJti,
+            'type'  => 'refresh',
+        ];
+
+        $refreshToken  = JwtHelper::encode($refreshClaims, $this->refreshTokenTtl);
+        $refreshExpiry = (new DateTimeImmutable())->add(new DateInterval('PT' . $this->refreshTokenTtl . 'S'));
+
+        $this->refreshTokenModel->create(
+            (int)$client['id'],
+            $refreshJti,
+            $this->hashToken($refreshToken),
+            $accessJti,
+            $scopes,
+            $refreshExpiry
+        );
+
+        return [
+            'token_type'         => 'Bearer',
+            'access_token'       => $accessToken,
+            'refresh_token'      => $refreshToken,
+            'expires_in'         => $this->accessTokenTtl,
+            'refresh_expires_in' => $this->refreshTokenTtl,
+            'scope'              => $scopeString,
+            'jti'                => $accessJti,
+            'client_id'          => (string)$client['client_id'],
+        ];
+    }
+
+    private function hashToken(string $token): string
+    {
+        return hash('sha256', $token);
+    }
+
+    private function uuid(): string
+    {
+        $data = random_bytes(16);
+        $data[6] = chr((ord($data[6]) & 0x0f) | 0x40);
+        $data[8] = chr((ord($data[8]) & 0x3f) | 0x80);
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
     }
 }

--- a/Backend/admin/Controllers/ApiClientController.php
+++ b/Backend/admin/Controllers/ApiClientController.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers;
+
+require_once __DIR__ . '/../Middleware/AuthMiddleware.php';
+require_once __DIR__ . '/../Models/ApiClientModel.php';
+require_once __DIR__ . '/../Helpers/ApiScopeHelper.php';
+require_once __DIR__ . '/../Helpers/ApiAuthConfig.php';
+
+use App\Helpers\ApiAuthConfig;
+use App\Helpers\ApiScopeHelper;
+use App\Middleware\AuthMiddleware;
+use App\Models\ApiClientModel;
+use Throwable;
+
+AuthMiddleware::verificarSesion();
+
+class ApiClientController
+{
+    public function __construct(private readonly ApiClientModel $apiClientModel = new ApiClientModel())
+    {
+    }
+
+    public function index(): void
+    {
+        $clients          = $this->apiClientModel->all();
+        $supportedScopes  = ApiScopeHelper::descriptions();
+        $title            = 'API Tokens - AS';
+        $headerTitle      = 'Credenciales API y Tokens';
+        $expectedAudience = ApiAuthConfig::expectedAudience();
+        $flashCredentials = $_SESSION['api_client_credentials'] ?? null;
+        $errorMessage     = $_SESSION['api_client_error'] ?? null;
+
+        unset($_SESSION['api_client_credentials'], $_SESSION['api_client_error']);
+
+        $contentView = __DIR__ . '/../Views/api-clients/index.php';
+        include __DIR__ . '/../Views/layouts/main.php';
+    }
+
+    public function store(): void
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+            $this->redirectWithError('Método no permitido.');
+            return;
+        }
+
+        $name      = trim((string)($_POST['name'] ?? ''));
+        $scopes    = isset($_POST['scopes']) ? (array)$_POST['scopes'] : [];
+        $rateLimit = (int)($_POST['rate_limit'] ?? 60);
+
+        if ($name === '') {
+            $this->redirectWithError('El nombre es obligatorio.');
+            return;
+        }
+
+        $scopes = ApiScopeHelper::filter($scopes);
+        if ($scopes === []) {
+            $this->redirectWithError('Selecciona al menos un scope.');
+            return;
+        }
+
+        try {
+            $result = $this->apiClientModel->createClient($name, $scopes, max(1, $rateLimit));
+            $_SESSION['api_client_credentials'] = [
+                'title'         => 'Cliente creado',
+                'client_id'     => $result['client_id'],
+                'client_secret' => $result['client_secret'],
+                'scopes'        => $scopes,
+            ];
+        } catch (Throwable $exception) {
+            $this->redirectWithError($exception->getMessage());
+            return;
+        }
+
+        $this->redirectToIndex();
+    }
+
+    public function rotateSecret(): void
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+            $this->redirectWithError('Método no permitido.');
+            return;
+        }
+
+        $clientId = (int)($_POST['client_id'] ?? 0);
+        if ($clientId <= 0) {
+            $this->redirectWithError('Cliente inválido.');
+            return;
+        }
+
+        try {
+            $result = $this->apiClientModel->rotateSecret($clientId);
+            $_SESSION['api_client_credentials'] = [
+                'title'         => 'Se generó un nuevo secreto',
+                'client_id'     => $result['client_id'],
+                'client_secret' => $result['client_secret'],
+                'is_rotation'   => true,
+            ];
+        } catch (Throwable $exception) {
+            $this->redirectWithError($exception->getMessage());
+            return;
+        }
+
+        $this->redirectToIndex();
+    }
+
+    private function redirectToIndex(): void
+    {
+        header('Location: ' . admin_base_url('api-clients'));
+        exit;
+    }
+
+    private function redirectWithError(string $message): void
+    {
+        $_SESSION['api_client_error'] = $message;
+        $this->redirectToIndex();
+    }
+}

--- a/Backend/admin/Helpers/ApiAuthConfig.php
+++ b/Backend/admin/Helpers/ApiAuthConfig.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+class ApiAuthConfig
+{
+    public static function expectedAudience(): string
+    {
+        $value = $_ENV['API_EXPECTED_AUDIENCE']
+            ?? getenv('API_EXPECTED_AUDIENCE')
+            ?? 'n8n-integrations';
+
+        $value = is_string($value) ? trim($value) : '';
+
+        return $value !== '' ? $value : 'n8n-integrations';
+    }
+
+    public static function accessTokenTtl(): int
+    {
+        $value = (int)($_ENV['API_ACCESS_TOKEN_TTL']
+            ?? getenv('API_ACCESS_TOKEN_TTL')
+            ?? 3600);
+
+        return max(300, $value);
+    }
+
+    public static function refreshTokenTtl(): int
+    {
+        $value = (int)($_ENV['API_REFRESH_TOKEN_TTL']
+            ?? getenv('API_REFRESH_TOKEN_TTL')
+            ?? 2592000); // 30 días
+
+        return max(3600, $value);
+    }
+}

--- a/Backend/admin/Helpers/ApiScopeHelper.php
+++ b/Backend/admin/Helpers/ApiScopeHelper.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+/**
+ * Catálogo centralizado de scopes soportados por la API.
+ */
+class ApiScopeHelper
+{
+    /** @var array<string, string> */
+    private const SCOPES = [
+        'auth.tokens'    => 'Permite refrescar y revocar tokens.',
+        'tenants.read'   => 'Lectura de información de inquilinos.',
+        'tenants.write'  => 'Alta o actualización de inquilinos.',
+        'policies.read'  => 'Consulta de pólizas y relaciones.',
+        'payments.write' => 'Registro de pagos ligados a pólizas.',
+        'documents.read' => 'Acceso a URLs firmadas de documentos.',
+        'webhooks.ingest'=> 'Ingesta de eventos externos.',
+    ];
+
+    /**
+     * Regresa el listado completo de scopes con su descripción.
+     *
+     * @return array<string, string>
+     */
+    public static function descriptions(): array
+    {
+        return self::SCOPES;
+    }
+
+    /**
+     * Devuelve solamente los scopes válidos, normalizados y sin duplicados.
+     *
+     * @param array<int, string> $scopes
+     * @return array<int, string>
+     */
+    public static function filter(array $scopes): array
+    {
+        $validKeys = array_keys(self::SCOPES);
+        $normalized = [];
+
+        foreach ($scopes as $scope) {
+            if (!is_string($scope)) {
+                continue;
+            }
+
+            $scope = trim($scope);
+            if ($scope === '') {
+                continue;
+            }
+
+            if (in_array($scope, $validKeys, true)) {
+                $normalized[$scope] = true;
+            }
+        }
+
+        return array_values(array_keys($normalized));
+    }
+}

--- a/Backend/admin/Models/ApiClientModel.php
+++ b/Backend/admin/Models/ApiClientModel.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+require_once __DIR__ . '/../Core/Database.php';
+require_once __DIR__ . '/../Helpers/ApiScopeHelper.php';
+
+use App\Core\Database;
+use App\Helpers\ApiScopeHelper;
+use PDO;
+use RuntimeException;
+
+class ApiClientModel extends Database
+{
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_SUSPENDED = 'suspended';
+    public const STATUS_REVOKED = 'revoked';
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function all(): array
+    {
+        $sql = 'SELECT id, client_id, name, secret_hash, allowed_scopes, status, rate_limit_per_minute, last_used_at, created_at, updated_at'
+            . ' FROM api_clients'
+            . ' ORDER BY created_at DESC';
+
+        $rows = $this->fetchAll($sql);
+
+        return array_map(function (array $row): array {
+            $mapped = $this->mapRow($row);
+            unset($mapped['secret_hash']);
+
+            return $mapped;
+        }, $rows);
+    }
+
+    public function findByClientId(string $clientId): ?array
+    {
+        $sql  = 'SELECT * FROM api_clients WHERE client_id = :client_id LIMIT 1';
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':client_id' => $clientId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ? $this->mapRow($row) : null;
+    }
+
+    public function findById(int $id): ?array
+    {
+        $sql  = 'SELECT * FROM api_clients WHERE id = :id LIMIT 1';
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ? $this->mapRow($row) : null;
+    }
+
+    /**
+     * @param array<int, string> $scopes
+     * @return array{client_id: string, client_secret: string, name: string}
+     */
+    public function createClient(string $name, array $scopes, int $rateLimitPerMinute = 60, string $status = self::STATUS_ACTIVE): array
+    {
+        $name = trim($name);
+        if ($name === '') {
+            throw new RuntimeException('El nombre del cliente es obligatorio.');
+        }
+
+        $scopes = ApiScopeHelper::filter($scopes);
+        if ($scopes === []) {
+            throw new RuntimeException('Selecciona al menos un scope.');
+        }
+
+        if (!in_array($status, [self::STATUS_ACTIVE, self::STATUS_SUSPENDED, self::STATUS_REVOKED], true)) {
+            throw new RuntimeException('Estado inválido.');
+        }
+
+        $clientId     = $this->generateUniqueClientId();
+        $clientSecret = $this->generateSecret();
+        $secretHash   = password_hash($clientSecret, PASSWORD_DEFAULT);
+
+        $sql = 'INSERT INTO api_clients (client_id, name, secret_hash, allowed_scopes, status, rate_limit_per_minute, created_at, updated_at)'
+            . ' VALUES (:client_id, :name, :secret_hash, :scopes, :status, :rate_limit, NOW(), NOW())';
+
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([
+            ':client_id'  => $clientId,
+            ':name'       => $name,
+            ':secret_hash'=> $secretHash,
+            ':scopes'     => json_encode($scopes, JSON_UNESCAPED_SLASHES),
+            ':status'     => $status,
+            ':rate_limit' => max(1, $rateLimitPerMinute),
+        ]);
+
+        return [
+            'client_id'     => $clientId,
+            'client_secret' => $clientSecret,
+            'name'          => $name,
+        ];
+    }
+
+    /**
+     * @return array{client_id: string, client_secret: string}
+     */
+    public function rotateSecret(int $id): array
+    {
+        $client = $this->findById($id);
+        if (!$client) {
+            throw new RuntimeException('Cliente no encontrado.');
+        }
+
+        $secret      = $this->generateSecret();
+        $secretHash  = password_hash($secret, PASSWORD_DEFAULT);
+        $sql         = 'UPDATE api_clients SET secret_hash = :secret, updated_at = NOW() WHERE id = :id LIMIT 1';
+        $stmt        = $this->db->prepare($sql);
+        $stmt->execute([':secret' => $secretHash, ':id' => $id]);
+
+        return [
+            'client_id'     => $client['client_id'],
+            'client_secret' => $secret,
+        ];
+    }
+
+    public function updateStatus(int $id, string $status): void
+    {
+        if (!in_array($status, [self::STATUS_ACTIVE, self::STATUS_SUSPENDED, self::STATUS_REVOKED], true)) {
+            throw new RuntimeException('Estado inválido.');
+        }
+
+        $sql  = 'UPDATE api_clients SET status = :status, updated_at = NOW() WHERE id = :id LIMIT 1';
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':status' => $status, ':id' => $id]);
+    }
+
+    public function touchLastUsed(int $id): void
+    {
+        $sql  = 'UPDATE api_clients SET last_used_at = NOW(), updated_at = NOW() WHERE id = :id LIMIT 1';
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':id' => $id]);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function mapRow(array $row): array
+    {
+        $row['allowed_scopes'] = $this->decodeScopes($row['allowed_scopes'] ?? '[]');
+
+        return $row;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function decodeScopes(string $payload): array
+    {
+        $decoded = json_decode($payload, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return ApiScopeHelper::filter($decoded);
+    }
+
+    private function generateUniqueClientId(): string
+    {
+        do {
+            $candidate = 'cli_' . bin2hex(random_bytes(8));
+            $exists    = $this->findByClientId($candidate);
+        } while ($exists !== null);
+
+        return $candidate;
+    }
+
+    private function generateSecret(): string
+    {
+        return bin2hex(random_bytes(32));
+    }
+}

--- a/Backend/admin/Models/ApiRefreshTokenModel.php
+++ b/Backend/admin/Models/ApiRefreshTokenModel.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+require_once __DIR__ . '/../Core/Database.php';
+
+use App\Core\Database;
+use DateTimeInterface;
+use PDO;
+
+class ApiRefreshTokenModel extends Database
+{
+    public function create(
+        int $clientId,
+        string $refreshJti,
+        string $refreshTokenHash,
+        string $accessJti,
+        array $scopes,
+        DateTimeInterface $expiresAt
+    ): void {
+        $sql = 'INSERT INTO api_refresh_tokens'
+            . ' (client_id, refresh_jti, refresh_token_hash, access_jti, scopes, expires_at, issued_at)'
+            . ' VALUES (:client_id, :refresh_jti, :hash, :access_jti, :scopes, :expires_at, NOW())';
+
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([
+            ':client_id'   => $clientId,
+            ':refresh_jti' => $refreshJti,
+            ':hash'        => $refreshTokenHash,
+            ':access_jti'  => $accessJti,
+            ':scopes'      => json_encode($scopes, JSON_UNESCAPED_SLASHES),
+            ':expires_at'  => $expiresAt->format('Y-m-d H:i:s'),
+        ]);
+    }
+
+    public function findActiveByJti(string $refreshJti): ?array
+    {
+        $sql  = 'SELECT * FROM api_refresh_tokens'
+            . ' WHERE refresh_jti = :jti AND consumed_at IS NULL AND expires_at > NOW()'
+            . ' LIMIT 1';
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':jti' => $refreshJti]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ?: null;
+    }
+
+    public function markConsumed(int $id): void
+    {
+        $sql  = 'UPDATE api_refresh_tokens SET consumed_at = NOW() WHERE id = :id LIMIT 1';
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':id' => $id]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function extractScopes(array $row): array
+    {
+        $payload = $row['scopes'] ?? '[]';
+        $decoded = json_decode((string)$payload, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map('strval', $decoded)));
+    }
+}

--- a/Backend/admin/Models/ApiTokenRevocationModel.php
+++ b/Backend/admin/Models/ApiTokenRevocationModel.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+require_once __DIR__ . '/../Core/Database.php';
+
+use App\Core\Database;
+use DateTimeInterface;
+
+class ApiTokenRevocationModel extends Database
+{
+    public function isRevoked(string $jti): bool
+    {
+        $sql  = 'SELECT 1 FROM api_token_revocations WHERE jti = :jti AND expires_at > NOW() LIMIT 1';
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':jti' => $jti]);
+
+        return (bool)$stmt->fetchColumn();
+    }
+
+    public function revoke(string $jti, string $tokenType, ?string $reason, ?string $revokedBy, DateTimeInterface $expiresAt): void
+    {
+        $sql = 'INSERT INTO api_token_revocations (jti, token_type, reason, revoked_by, revoked_at, expires_at)'
+            . ' VALUES (:jti, :token_type, :reason, :revoked_by, NOW(), :expires_at)'
+            . ' ON DUPLICATE KEY UPDATE reason = VALUES(reason), revoked_by = VALUES(revoked_by), revoked_at = NOW(), expires_at = VALUES(expires_at)';
+
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([
+            ':jti'        => $jti,
+            ':token_type' => $tokenType,
+            ':reason'     => $reason,
+            ':revoked_by' => $revokedBy,
+            ':expires_at' => $expiresAt->format('Y-m-d H:i:s'),
+        ]);
+    }
+}

--- a/Backend/admin/Views/api-clients/index.php
+++ b/Backend/admin/Views/api-clients/index.php
@@ -1,0 +1,218 @@
+<?php
+/** @var array<int, array<string, mixed>> $clients */
+/** @var array<string, string> $supportedScopes */
+/** @var array<string, mixed>|null $flashCredentials */
+/** @var string|null $errorMessage */
+/** @var string $expectedAudience */
+
+$clients          = $clients ?? [];
+$supportedScopes  = $supportedScopes ?? [];
+$flashCredentials = $flashCredentials ?? null;
+$errorMessage     = $errorMessage ?? null;
+$expectedAudience = $expectedAudience ?? 'n8n-integrations';
+
+if (!function_exists('status_badge_class')) {
+    function status_badge_class(string $status): string
+    {
+        return match ($status) {
+            'active'    => 'bg-emerald-500/20 text-emerald-200 border border-emerald-400/30',
+            'suspended' => 'bg-amber-500/20 text-amber-200 border border-amber-400/30',
+            'revoked'   => 'bg-red-500/20 text-red-200 border border-red-400/40',
+            default     => 'bg-slate-500/20 text-slate-200 border border-slate-400/30',
+        };
+    }
+}
+?>
+
+<div class="space-y-8">
+    <section class="bg-white/5 border border-white/10 rounded-2xl p-6 shadow-xl text-slate-100">
+        <div class="flex items-center justify-between flex-wrap gap-4">
+            <div>
+                <h1 class="text-2xl font-bold">Centro de credenciales API</h1>
+                <p class="text-sm text-slate-300 mt-1">Registra clientes, entrega secretos y controla qué scopes pueden usar tus integraciones.</p>
+            </div>
+            <div class="text-right">
+                <span class="text-xs uppercase tracking-wide text-slate-400">Audience esperada</span>
+                <p class="text-lg font-semibold text-emerald-300"><?= htmlspecialchars($expectedAudience, ENT_QUOTES, 'UTF-8') ?></p>
+            </div>
+        </div>
+    </section>
+
+    <?php if (!empty($errorMessage)): ?>
+        <div class="bg-red-500/20 border border-red-500/40 text-red-100 rounded-xl p-4">
+            <p class="font-semibold">Algo salió mal</p>
+            <p class="text-sm mt-1"><?= htmlspecialchars($errorMessage, ENT_QUOTES, 'UTF-8') ?></p>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($flashCredentials) && is_array($flashCredentials)): ?>
+        <div class="bg-emerald-500/10 border border-emerald-400/40 rounded-2xl p-5 text-emerald-50 shadow-lg">
+            <h2 class="text-xl font-semibold flex items-center gap-2">
+                <span>🔐 <?= htmlspecialchars($flashCredentials['title'] ?? 'Credenciales generadas', ENT_QUOTES, 'UTF-8') ?></span>
+            </h2>
+            <p class="text-sm text-emerald-100 mt-1">Guarda estos datos en tu orquestador seguro. El secreto sólo aparece una vez.</p>
+            <div class="mt-4 grid md:grid-cols-2 gap-4">
+                <div class="bg-black/20 rounded-xl p-4">
+                    <p class="text-xs uppercase tracking-wide text-emerald-200">Client ID</p>
+                    <div class="flex items-center gap-2 mt-1">
+                        <code class="text-sm break-all"><?= htmlspecialchars($flashCredentials['client_id'] ?? '', ENT_QUOTES, 'UTF-8') ?></code>
+                        <button type="button" class="text-xs px-2 py-1 bg-emerald-400/20 rounded-lg border border-emerald-300/30 hover:bg-emerald-400/40"
+                            data-copy="<?= htmlspecialchars($flashCredentials['client_id'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                            Copiar
+                        </button>
+                    </div>
+                </div>
+                <div class="bg-black/20 rounded-xl p-4">
+                    <p class="text-xs uppercase tracking-wide text-emerald-200">Client secret</p>
+                    <div class="flex items-center gap-2 mt-1">
+                        <code class="text-sm break-all"><?= htmlspecialchars($flashCredentials['client_secret'] ?? '', ENT_QUOTES, 'UTF-8') ?></code>
+                        <button type="button" class="text-xs px-2 py-1 bg-emerald-400/20 rounded-lg border border-emerald-300/30 hover:bg-emerald-400/40"
+                            data-copy="<?= htmlspecialchars($flashCredentials['client_secret'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                            Copiar
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <div class="grid lg:grid-cols-2 gap-6">
+        <div class="bg-white/5 border border-white/10 rounded-2xl p-6">
+            <h3 class="text-lg font-semibold mb-3 flex items-center gap-2">✨ Nuevo cliente API</h3>
+            <form action="<?= admin_base_url('api-clients') ?>" method="POST" class="space-y-4">
+                <div>
+                    <label class="block text-sm mb-1 text-slate-200" for="client-name">Nombre visible</label>
+                    <input type="text" id="client-name" name="name" class="w-full rounded-xl bg-black/30 border border-white/10 px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-400" placeholder="n8n Producción" required>
+                </div>
+                <div>
+                    <label class="block text-sm mb-1 text-slate-200" for="rate-limit">Límite por minuto</label>
+                    <input type="number" min="1" id="rate-limit" name="rate_limit" value="60" class="w-full rounded-xl bg-black/30 border border-white/10 px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-400">
+                </div>
+                <div>
+                    <p class="block text-sm mb-2 text-slate-200">Scopes permitidos</p>
+                    <div class="grid sm:grid-cols-2 gap-2 max-h-64 overflow-y-auto pr-1">
+                        <?php foreach ($supportedScopes as $scope => $description): ?>
+                            <label class="flex items-start gap-2 bg-black/20 rounded-xl p-3 border border-white/5 hover:border-indigo-400/60 cursor-pointer">
+                                <input type="checkbox" name="scopes[]" value="<?= htmlspecialchars($scope, ENT_QUOTES, 'UTF-8') ?>" class="mt-1 text-indigo-500 focus:ring-indigo-400">
+                                <span>
+                                    <span class="text-sm font-semibold text-slate-100"><?= htmlspecialchars($scope, ENT_QUOTES, 'UTF-8') ?></span>
+                                    <span class="block text-xs text-slate-400 leading-tight"><?= htmlspecialchars($description, ENT_QUOTES, 'UTF-8') ?></span>
+                                </span>
+                            </label>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+                <button type="submit" class="w-full bg-indigo-500 hover:bg-indigo-400 transition text-white font-semibold rounded-xl py-3 shadow-lg shadow-indigo-500/30">Crear cliente</button>
+            </form>
+        </div>
+        <div class="bg-white/5 border border-white/10 rounded-2xl p-6 space-y-3 text-slate-200">
+            <h3 class="text-lg font-semibold flex items-center gap-2">📋 Tips rápidos</h3>
+            <ul class="space-y-3 text-sm text-slate-300">
+                <li class="flex gap-2">
+                    <span>•</span>
+                    <span>Comparte el <strong>client_id</strong>, <strong>client_secret</strong> y el audience <code><?= htmlspecialchars($expectedAudience, ENT_QUOTES, 'UTF-8') ?></code> para el endpoint <code>/api/auth/login</code>.</span>
+                </li>
+                <li class="flex gap-2">
+                    <span>•</span>
+                    <span>Los scopes limitan lo que cada automatización puede consultar. Selecciona sólo lo que necesita.</span>
+                </li>
+                <li class="flex gap-2">
+                    <span>•</span>
+                    <span>Si se compromete un secreto, usa el botón “Rotar secreto” en la tabla para invalidar el anterior.</span>
+                </li>
+                <li class="flex gap-2">
+                    <span>•</span>
+                    <span>Cuando un cliente no se usa más, suspéndelo directamente desde la base de datos o revoca sus tokens.</span>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+    <section class="bg-white/5 border border-white/10 rounded-2xl p-6">
+        <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+            <h3 class="text-lg font-semibold text-slate-100">Clientes registrados</h3>
+            <p class="text-sm text-slate-400"><?= count($clients) ?> clientes activos en total.</p>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="min-w-full text-sm text-slate-200">
+                <thead class="text-xs uppercase text-slate-400">
+                    <tr>
+                        <th class="text-left py-2 pr-3">Cliente</th>
+                        <th class="text-left py-2 pr-3">Scopes</th>
+                        <th class="text-left py-2 pr-3">Límite</th>
+                        <th class="text-left py-2 pr-3">Último uso</th>
+                        <th class="text-right py-2">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($clients)): ?>
+                        <tr>
+                            <td colspan="5" class="text-center py-6 text-slate-400">Aún no hay clientes registrados.</td>
+                        </tr>
+                    <?php endif; ?>
+                    <?php foreach ($clients as $client): ?>
+                        <tr class="border-t border-white/5">
+                            <td class="py-4 pr-3 align-top">
+                                <p class="font-semibold text-white flex items-center gap-2">
+                                    <?= htmlspecialchars($client['name'] ?? '', ENT_QUOTES, 'UTF-8') ?>
+                                    <span class="text-xs px-2 py-0.5 rounded-full <?= status_badge_class($client['status'] ?? '') ?>">
+                                        <?= htmlspecialchars($client['status'] ?? 'unknown', ENT_QUOTES, 'UTF-8') ?>
+                                    </span>
+                                </p>
+                                <p class="text-xs text-slate-400 break-all mt-1">ID: <?= htmlspecialchars($client['client_id'] ?? '', ENT_QUOTES, 'UTF-8') ?></p>
+                            </td>
+                            <td class="py-4 pr-3 align-top">
+                                <div class="flex flex-wrap gap-1">
+                                    <?php foreach (($client['allowed_scopes'] ?? []) as $scope): ?>
+                                        <span class="px-2 py-0.5 text-xs rounded-full bg-indigo-500/20 border border-indigo-400/30">
+                                            <?= htmlspecialchars($scope, ENT_QUOTES, 'UTF-8') ?>
+                                        </span>
+                                    <?php endforeach; ?>
+                                </div>
+                            </td>
+                            <td class="py-4 pr-3 align-top">
+                                <?= isset($client['rate_limit_per_minute']) ? (int)$client['rate_limit_per_minute'] : 0 ?> rpm
+                            </td>
+                            <td class="py-4 pr-3 align-top text-slate-400">
+                                <?php if (!empty($client['last_used_at'])): ?>
+                                    <?= htmlspecialchars(date('d M Y H:i', strtotime((string)$client['last_used_at'])), ENT_QUOTES, 'UTF-8') ?>
+                                <?php else: ?>
+                                    —
+                                <?php endif; ?>
+                            </td>
+                            <td class="py-4 text-right align-top">
+                                <form action="<?= admin_base_url('api-clients/rotate-secret') ?>" method="POST" class="inline-flex flex-col items-end gap-2">
+                                    <input type="hidden" name="client_id" value="<?= (int)($client['id'] ?? 0) ?>">
+                                    <button type="submit" class="text-xs px-3 py-1.5 rounded-full border border-amber-400/50 text-amber-200 hover:bg-amber-400/20">Rotar secreto</button>
+                                    <button type="button" class="text-xs text-slate-300 underline" data-copy="<?= htmlspecialchars($client['client_id'] ?? '', ENT_QUOTES, 'UTF-8') ?>">Copiar ID</button>
+                                </form>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </section>
+</div>
+
+<script>
+    document.querySelectorAll('[data-copy]').forEach((button) => {
+        button.addEventListener('click', async () => {
+            const value = button.getAttribute('data-copy');
+            if (!value) {
+                return;
+            }
+
+            try {
+                await navigator.clipboard.writeText(value);
+                button.textContent = 'Copiado';
+                setTimeout(() => {
+                    button.textContent = 'Copiar';
+                }, 1500);
+            } catch (error) {
+                console.error('No se pudo copiar', error);
+            }
+        });
+    });
+
+</script>

--- a/Backend/admin/Views/layouts/_sidebar.php
+++ b/Backend/admin/Views/layouts/_sidebar.php
@@ -107,6 +107,15 @@
         Blog
       </a>
       <hr class="my-3 border-indigo-900/30" />
+      <!-- nav: API Tokens -->
+      <a href="<?= $baseUrl ?>/api-clients" class=" sidebar-link flex items-center gap-3 px-4 py-3 rounded-xl" data-path="api-clients">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 1 1 2.122 5.122l-7.99 7.99a4.5 4.5 0 0 1-6.364-6.364l7.99-7.99A3 3 0 0 1 15.75 5.25Z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 15.75h6" />
+        </svg>
+        API Tokens
+      </a>
+      <hr class="my-3 border-indigo-900/30" />
       <!-- nav: Asesores -->
       <a href="<?= $baseUrl ?>/asesores" class=" sidebar-link flex items-center gap-3 px-4 py-3 rounded-xl " data-path="asesores">
         <!-- Lucide: Newspaper -->

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -191,6 +191,24 @@ switch (true) {
         exit;
         break;
 
+    case $uri === '/api-clients' && $_SERVER['REQUEST_METHOD'] === 'GET':
+        require __DIR__ . '/Controllers/ApiClientController.php';
+        (new \App\Controllers\ApiClientController())->index();
+        exit;
+        break;
+
+    case $uri === '/api-clients' && $_SERVER['REQUEST_METHOD'] === 'POST':
+        require __DIR__ . '/Controllers/ApiClientController.php';
+        (new \App\Controllers\ApiClientController())->store();
+        exit;
+        break;
+
+    case $uri === '/api-clients/rotate-secret' && $_SERVER['REQUEST_METHOD'] === 'POST':
+        require __DIR__ . '/Controllers/ApiClientController.php';
+        (new \App\Controllers\ApiClientController())->rotateSecret();
+        exit;
+        break;
+
     // Logout
     case $uri === '/logout':
         require __DIR__ . '/Controllers/AuthController.php';


### PR DESCRIPTION
## Summary
- introduce models and helpers to manage API clients, refresh tokens and revocations from the database
- update the API auth controller and middleware to issue JWTs for registered clients, persist refresh tokens and honor revocation lists
- add a CRM screen plus navigation entry to create clients, view scopes and rotate secrets from the admin panel

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691acc874e1c8323932760b0da4dcb7f)