### PR TITLE
Rename API clients panel route

### DIFF
--- a/Backend/admin/Controllers/ApiClientController.php
+++ b/Backend/admin/Controllers/ApiClientController.php
@@ -19,6 +19,8 @@ AuthMiddleware::verificarSesion();
 
 class ApiClientController
 {
+    private const PANEL_ROUTE = 'integrations/clients';
+
     public function __construct(private readonly ApiClientModel $apiClientModel = new ApiClientModel())
     {
     }
@@ -108,7 +110,7 @@ class ApiClientController
 
     private function redirectToIndex(): void
     {
-        header('Location: ' . admin_base_url('api-clients'));
+        header('Location: ' . admin_base_url(self::PANEL_ROUTE));
         exit;
     }
 

--- a/Backend/admin/Views/api-clients/index.php
+++ b/Backend/admin/Views/api-clients/index.php
@@ -79,7 +79,7 @@ if (!function_exists('status_badge_class')) {
     <div class="grid lg:grid-cols-2 gap-6">
         <div class="bg-white/5 border border-white/10 rounded-2xl p-6">
             <h3 class="text-lg font-semibold mb-3 flex items-center gap-2">✨ Nuevo cliente API</h3>
-            <form action="<?= admin_base_url('api-clients') ?>" method="POST" class="space-y-4">
+            <form action="<?= admin_base_url('integrations/clients') ?>" method="POST" class="space-y-4">
                 <div>
                     <label class="block text-sm mb-1 text-slate-200" for="client-name">Nombre visible</label>
                     <input type="text" id="client-name" name="name" class="w-full rounded-xl bg-black/30 border border-white/10 px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-400" placeholder="n8n Producción" required>
@@ -181,7 +181,7 @@ if (!function_exists('status_badge_class')) {
                                 <?php endif; ?>
                             </td>
                             <td class="py-4 text-right align-top">
-                                <form action="<?= admin_base_url('api-clients/rotate-secret') ?>" method="POST" class="inline-flex flex-col items-end gap-2">
+                                <form action="<?= admin_base_url('integrations/clients/rotate-secret') ?>" method="POST" class="inline-flex flex-col items-end gap-2">
                                     <input type="hidden" name="client_id" value="<?= (int)($client['id'] ?? 0) ?>">
                                     <button type="submit" class="text-xs px-3 py-1.5 rounded-full border border-amber-400/50 text-amber-200 hover:bg-amber-400/20">Rotar secreto</button>
                                     <button type="button" class="text-xs text-slate-300 underline" data-copy="<?= htmlspecialchars($client['client_id'] ?? '', ENT_QUOTES, 'UTF-8') ?>">Copiar ID</button>

--- a/Backend/admin/Views/layouts/_sidebar.php
+++ b/Backend/admin/Views/layouts/_sidebar.php
@@ -108,7 +108,7 @@
       </a>
       <hr class="my-3 border-indigo-900/30" />
       <!-- nav: API Tokens -->
-      <a href="<?= $baseUrl ?>/api-clients" class=" sidebar-link flex items-center gap-3 px-4 py-3 rounded-xl" data-path="api-clients">
+      <a href="<?= $baseUrl ?>/integrations/clients" class=" sidebar-link flex items-center gap-3 px-4 py-3 rounded-xl" data-path="integrations/clients">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 1 1 2.122 5.122l-7.99 7.99a4.5 4.5 0 0 1-6.364-6.364l7.99-7.99A3 3 0 0 1 15.75 5.25Z" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 15.75h6" />

--- a/Backend/admin/router.php
+++ b/Backend/admin/router.php
@@ -191,19 +191,19 @@ switch (true) {
         exit;
         break;
 
-    case $uri === '/api-clients' && $_SERVER['REQUEST_METHOD'] === 'GET':
+    case $uri === '/integrations/clients' && $_SERVER['REQUEST_METHOD'] === 'GET':
         require __DIR__ . '/Controllers/ApiClientController.php';
         (new \App\Controllers\ApiClientController())->index();
         exit;
         break;
 
-    case $uri === '/api-clients' && $_SERVER['REQUEST_METHOD'] === 'POST':
+    case $uri === '/integrations/clients' && $_SERVER['REQUEST_METHOD'] === 'POST':
         require __DIR__ . '/Controllers/ApiClientController.php';
         (new \App\Controllers\ApiClientController())->store();
         exit;
         break;
 
-    case $uri === '/api-clients/rotate-secret' && $_SERVER['REQUEST_METHOD'] === 'POST':
+    case $uri === '/integrations/clients/rotate-secret' && $_SERVER['REQUEST_METHOD'] === 'POST':
         require __DIR__ . '/Controllers/ApiClientController.php';
         (new \App\Controllers\ApiClientController())->rotateSecret();
         exit;


### PR DESCRIPTION
## Summary
- move the API clients panel off the `/api` prefix by routing it through `/integrations/clients`
- update the controller redirects, views, and sidebar links to use the new route so the UI keeps working

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c1d27bb0083238d1e157043334da1)