### PR TITLE
Handle redirect authorization header

### DIFF
--- a/Backend/admin/Middleware/ApiTokenMiddleware.php
+++ b/Backend/admin/Middleware/ApiTokenMiddleware.php
@@ -194,6 +194,10 @@ class ApiTokenMiddleware
             return (string)$_SERVER['HTTP_AUTHORIZATION'];
         }
 
+        if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+            return (string)$_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+        }
+
         if (isset($_SERVER['Authorization'])) {
             return (string)$_SERVER['Authorization'];
         }


### PR DESCRIPTION
## Summary
- add support for `REDIRECT_HTTP_AUTHORIZATION` so Apache/IIS forwarded headers are accepted by the API token middleware

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbb592d3083239d937a44076de585)